### PR TITLE
KBV-368-update-regex-for-nonukPostcodes

### DIFF
--- a/src/app/address/validators/postcodeValidator.js
+++ b/src/app/address/validators/postcodeValidator.js
@@ -16,9 +16,12 @@ module.exports = {
   },
   isUkPostcode: function (val) {
     // taken from https://en.wikipedia.org/wiki/Postcodes_in_the_United_Kingdom#Validation
-    const ukPostcodeRegex =
-      /^(([A-Z]{1,2}[0-9][A-Z0-9]?|ASCN|STHL|TDCU|BBND|[BFS]IQQ|PCRN|TKCA) ?[0-9][A-Z]{2}|BFPO ?[0-9]{1,4}|(KY[0-9]|MSR|VG|AI)[ -]?[0-9]{4}|[A-Z]{2} ?[0-9]{2}|GE ?CX|GIR ?0A{2}|SAN ?TA1)$/i;
+    // simpler regex to just validate the postcode format
 
+    // 1 or 2 letters followed by a number
+    // optionally a letter or number
+    // A optional space followed by a number and two letters
+    const ukPostcodeRegex = /^[A-Z]{1,2}[0-9][A-Z0-9]? ?[0-9][A-Z]{2}$/i;
     return val.match(ukPostcodeRegex) ? true : false;
   },
 };

--- a/src/app/address/validators/postcodeValidator.test.js
+++ b/src/app/address/validators/postcodeValidator.test.js
@@ -5,7 +5,7 @@ const {
   isUkPostcode,
 } = require("./postcodeValidator");
 
-const validPostcodes = ["E18QS", "PA296YP"];
+const validPostcodes = ["E18QS", "PA296YP", "SW1A2AA", "AA11AA"];
 const invalidPostcodeLength = ["1", "88888888", "4444", ""];
 const invalidAlphaOnly = ["abcde", "VXYZ", "AbCdEf"];
 const invalidIntOnly = ["11111", "123456", "000000"];


### PR DESCRIPTION
## Proposed changes

### What changed

Refactor the regex to be more lenient with the passable strings. This will allow additional validation to handled by the OS API

### Why did it change

A stricter regex that is harder to understand is also harder to maintain and could result in additional problems later in development. If new postcodes are added then this regex should act a formal catch all and additional validation can be handled by the external OS API.

### Issue tracking

- [KBV-368](https://govukverify.atlassian.net/browse/KBV-368)
