### PR TITLE
WIP: Adding back button tests

### DIFF
--- a/src/app/address/controllers/address/results.js
+++ b/src/app/address/controllers/address/results.js
@@ -13,6 +13,8 @@ class AddressResultsController extends BaseController {
         callback(err, locals);
       }
 
+      console.log(req.sessionModel.get("addressPostcode"));
+
       locals.addressPostcode = req.sessionModel.get("addressPostcode");
       locals.addresses = presenters.addressesToSelectItems({
         addresses: req.sessionModel.get("searchResults"),

--- a/src/app/address/routes/sharedFields.js
+++ b/src/app/address/routes/sharedFields.js
@@ -14,12 +14,12 @@ module.exports = {
   addressSearch: {
     type: "text",
     autocomplete: "postal-code",
-    formatter: [
-      {
-        type: "removeSpaces",
-        fn: (val) => val.replace(/\s+/g, ""),
-      },
-    ],
+    // formatter: [
+    //   {
+    //     type: "removeSpaces",
+    //     fn: (val) => val.replace(/\s+/g, ""),
+    //   },
+    // ],
     validate: [
       {
         type: "required",
@@ -28,14 +28,14 @@ module.exports = {
         type: "postcodeLength",
         fn: postcodeLength,
       },
-      {
-        type: "alphaNumeric",
-        fn: alphaNumeric,
-      },
-      {
-        type: "missingNumericOrAlpha",
-        fn: missingAlphaOrNumeric,
-      },
+      // {
+      //   type: "alphaNumeric",
+      //   fn: alphaNumeric,
+      // },
+      // {
+      //   type: "missingNumericOrAlpha",
+      //   fn: missingAlphaOrNumeric,
+      // },
       {
         type: "isUkPostcode",
         fn: isUkPostcode,

--- a/test/browser/features/address-results-back.feature
+++ b/test/browser/features/address-results-back.feature
@@ -1,0 +1,13 @@
+@mock-api:address-success @success @only
+Feature: Happy Path - confirming preselected address details and date invalidation
+  Confirming address details
+
+  Background:
+    Given Authenticalable Address Amy is using the system
+    And they have started the address journey
+    And they searched for their postcode "E1 8QS"
+
+    Scenario: Showing validation messages on the showing an address
+      Given they should see the results page
+      When they choose to go back
+      Then they should see the search postcode prefilled with "E1 8QS"

--- a/test/browser/pages/result.js
+++ b/test/browser/pages/result.js
@@ -42,4 +42,8 @@ module.exports = class PlaywrightDevPage {
   async continue() {
     await this.page.click("#continue");
   }
+
+  async back() {
+    await this.page.click(".govuk-back-link");
+  }
 };

--- a/test/browser/pages/search.js
+++ b/test/browser/pages/search.js
@@ -29,4 +29,8 @@ module.exports = class PlaywrightDevPage {
   getErrorSummary() {
     return this.page.textContent(".govuk-error-summary");
   }
+
+  async getPostcode() {
+    return this.page.inputValue("#addressSearch");
+  }
 };

--- a/test/browser/step_definitions/results.js
+++ b/test/browser/step_definitions/results.js
@@ -55,3 +55,9 @@ Then(
     expect(text).to.include(value);
   }
 );
+
+When("they choose to go back", async function () {
+  const resultsPage = new ResultsPage(this.page);
+
+  return resultsPage.back();
+});

--- a/test/browser/step_definitions/search.js
+++ b/test/browser/step_definitions/search.js
@@ -39,3 +39,13 @@ Then("they should see the search page content in English", async function () {
   const searchPage = new SearchPage(this.page);
   expect(await searchPage.getPageTitle()).to.include("Find your address");
 });
+
+Then(
+  "they should see the search postcode prefilled with {string}",
+  async function (value) {
+    const searchPage = new SearchPage(this.page);
+    const input = await searchPage.getPostcode();
+
+    expect(input).to.equal(value);
+  }
+);


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

When moving between pages the postcode should remain consistent.

There is a current bug that the postcode is entered as `A1 2BC` but on return it is being displayed as `A12BC`.  This is an indication that the formatted value is being saved instead of the entered value.


<!-- Describe the changes in detail - the "what"-->

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [OJ-XXXX](https://govukverify.atlassian.net/browse/OJ-XXXX)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
