### PR TITLE
LIME-834 updating support link to one-login

### DIFF
--- a/src/locales/cy/default.yml
+++ b/src/locales/cy/default.yml
@@ -32,7 +32,7 @@ govuk:
     cookieLinkText: "Darganfyddwch fwy am gwcis"
   phaseBanner:
     tag: "beta"
-    content: 'Mae hwn yn wasanaeth newydd – bydd eich <a href="https://signin.account.gov.uk/contact-us" class="govuk-link" rel="noopener" target="_blank">adborth (agor mewn tab newydd)</a> yn ein helpu i''w wella.'
+    content: 'Mae hwn yn wasanaeth newydd – bydd eich <a href="https://home.account.gov.uk/contact-gov-uk-one-login" class="govuk-link" rel="noopener" target="_blank">adborth (agor mewn tab newydd)</a> yn ein helpu i''w wella.'
   footerNavItems:
     meta:
       items:
@@ -44,7 +44,7 @@ govuk:
           text: "Telerau ac amodau"
         - href: "https://signin.account.gov.uk/privacy-notice"
           text: "Hysbysiad preifatrwydd"
-        - href: "https://signin.account.gov.uk/contact-us"
+        - href: "https://home.account.gov.uk/contact-gov-uk-one-login"
           text: "Cymorth"
   copyright:
     text: "© Hawlfraint y goron"
@@ -73,7 +73,7 @@ links:
     cantFindAddress:
       - '<p><a href="/previous/address" data-id="cantFindAddress" class="govuk-link">Ni allaf ddod o hyd i fy nghyfeiriad ar y rhestr</a></p>'
   helpContact:
-    - '<p><a href="https://signin.account.gov.uk/contact-us?supportType=PUBLIC" target="_blank" class="govuk-link">Cysylltwch â’r tîm GOV.UK One Login (agor mewn tab newydd)</a></p>'
+    - '<p><a href="https://home.account.gov.uk/contact-gov-uk-one-login" target="_blank" class="govuk-link">Cysylltwch â’r tîm GOV.UK One Login (agor mewn tab newydd)</a></p>'
 validation:
   required: "Rhowch eich {{label}}"
   postcodeLength: "Dylai eich {{label}} fod rhwng 5 a 7 nod"

--- a/src/locales/en/default.yml
+++ b/src/locales/en/default.yml
@@ -32,7 +32,7 @@ govuk:
     cookieLinkText: "Find out more about cookies"
   phaseBanner:
     tag: beta
-    content: This is a new service – your <a href="https://signin.account.gov.uk/contact-us" class="govuk-link" rel="noopener" target="_blank">feedback (opens in new tab)</a> will help us to improve it.
+    content: This is a new service – your <a href="https://home.account.gov.uk/contact-gov-uk-one-login" class="govuk-link" rel="noopener" target="_blank">feedback (opens in new tab)</a> will help us to improve it.
   footerNavItems:
     meta:
       items:
@@ -44,7 +44,7 @@ govuk:
           text: Terms and conditions
         - href: https://signin.account.gov.uk/privacy-notice
           text: Privacy notice
-        - href: https://signin.account.gov.uk/contact-us
+        - href: https://home.account.gov.uk/contact-gov-uk-one-login
           text: Support
   copyright:
     text: "© Crown copyright"
@@ -75,7 +75,7 @@ links:
     cantFindAddress:
       - <p><a href="/previous/address" data-id="cantFindAddress" class="govuk-link">I cannot find my address in the list</a></p>
   helpContact:
-    - <p><a href="https://signin.account.gov.uk/contact-us?supportType=PUBLIC" target="_blank" class="govuk-link">Contact the GOV.UK One Login team (opens in a new tab)</a></p>
+    - <p><a href="https://home.account.gov.uk/contact-gov-uk-one-login" target="_blank" class="govuk-link">Contact the GOV.UK One Login team (opens in a new tab)</a></p>
 validation:
   required: Enter your {{label}}
   postcodeLength: "Your {{label}} should be between 5 and 7 characters"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

The support link has been changed to the new one-login version.

### Why did it change

Due to contact centre being onboarded to one-login.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [LIME-834](https://govukverify.atlassian.net/browse/LIME-834)

## Checklists

### Environment variables or secrets

[LIME-834]: https://govukverify.atlassian.net/browse/LIME-834?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ