### PR TITLE
OJ-1742: Increased max capacity for autoscaling to match IPV Core

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -460,7 +460,7 @@ Resources:
     Condition: IsProductionOrBuild
     Type: AWS::ApplicationAutoScaling::ScalableTarget
     Properties:
-      MaxCapacity: 4
+      MaxCapacity: 60
       MinCapacity: 2
       ResourceId: !Join
         - '/'


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Max capacity for auto scaling has been increased to 60, to match what is in core: https://github.com/govuk-one-login/ipv-core-front/blob/6199710a90ca8f68662ff0e8961dd2154294f28b/deploy/template.yaml#L457C10-L457C10

### Why did it change
During perf test, the current capacity was hit and the system was using 100% CPU. This causes HTTP 500 errors. 
The fix recommended by perf team is to increase this limit. 
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [OJ-1742](https://govukverify.atlassian.net/browse/OJ-1742)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[OJ-1742]: https://govukverify.atlassian.net/browse/OJ-1742?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ