### PR TITLE
IPS-295 Added wildcard match to end of dynatrace resource names

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -261,14 +261,14 @@
       {
         "type": "Secret Keyword",
         "filename": "deploy/template.yaml",
-        "hashed_secret": "bc794cebe558155f13aba1743457f906cb8bd7a9",
+        "hashed_secret": "19489ea41acf55b1e67d187515d63eb5dfe90fdb",
         "is_verified": false,
         "line_number": 389
       },
       {
         "type": "Secret Keyword",
         "filename": "deploy/template.yaml",
-        "hashed_secret": "8a874a3fb21250a2518578da2c545eee007741ce",
+        "hashed_secret": "267255d55ef750db3ab8dbc240ecc7f57554eeea",
         "is_verified": false,
         "line_number": 390
       },
@@ -290,5 +290,5 @@
       }
     ]
   },
-  "generated_at": "2023-11-20T16:18:51Z"
+  "generated_at": "2023-11-24T15:40:00Z"
 }

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -386,8 +386,8 @@ Resources:
                 Action:
                   - "secretsmanager:GetSecretValue" #pragma: allowlist secret
                 Resource:
-                  - "arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables"
-                  - "arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceProductionVariables"
+                  - "arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables*"
+                  - "arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceProductionVariables*"
               - Effect: Allow
                 Action:
                   - "secretsmanager:ListSecrets" #pragma: allowlist secret
@@ -439,8 +439,8 @@ Resources:
                 Action:
                   - "secretsmanager:GetSecretValue" #pragma: allowlist secret
                 Resource:
-                  - "arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables"
-                  - "arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceProductionVariables"
+                  - "arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables*"
+                  - "arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceProductionVariables*"
               - Effect: Allow
                 Action:
                   - "secretsmanager:ListSecrets" #pragma: allowlist secret


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
IPS-295 Added wildcard match to end of dynatrace resource names
<!-- Describe the changes in detail - the "what"-->

### Why did it change
IPS-295 Added wildcard match to end of dynatrace resource names
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [IPS-295](https://govukverify.atlassian.net/browse/IPS-295)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[IPS-295]: https://govukverify.atlassian.net/browse/IPS-295?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ