### PR TITLE
OJ-1684: Added health check configs to `LoadBalancerListenerTargetGro…

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -263,21 +263,21 @@
         "filename": "deploy/template.yaml",
         "hashed_secret": "19489ea41acf55b1e67d187515d63eb5dfe90fdb",
         "is_verified": false,
-        "line_number": 389
+        "line_number": 392
       },
       {
         "type": "Secret Keyword",
         "filename": "deploy/template.yaml",
         "hashed_secret": "267255d55ef750db3ab8dbc240ecc7f57554eeea",
         "is_verified": false,
-        "line_number": 390
+        "line_number": 393
       },
       {
         "type": "Secret Keyword",
         "filename": "deploy/template.yaml",
         "hashed_secret": "42af5cf9fcf4f09147c032a0fb4877f5cf626bbc",
         "is_verified": false,
-        "line_number": 395
+        "line_number": 398
       }
     ],
     "test/browser/compose.yml": [
@@ -290,5 +290,5 @@
       }
     ]
   },
-  "generated_at": "2023-11-24T15:40:00Z"
+  "generated_at": "2023-11-28T14:42:18Z"
 }

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -187,6 +187,9 @@ Resources:
       HealthCheckEnabled: TRUE
       HealthCheckProtocol: HTTP
       HealthCheckPath: /healthcheck
+      HealthCheckTimeoutSeconds: 2
+      HealthCheckIntervalSeconds: 5
+      HealthyThresholdCount: 2
       Matcher:
         HttpCode: 200
       Port: 80
@@ -197,7 +200,7 @@ Resources:
           !Sub "${VpcStackName}-VpcId"
       TargetGroupAttributes:
         - Key: deregistration_delay.timeout_seconds
-          Value: 60
+          Value: 30
 
   LoadBalancerListener:
     Type: 'AWS::ElasticLoadBalancingV2::Listener'


### PR DESCRIPTION
## Proposed changes

### What changed
`template.yaml` added health checking configs to `LoadBalancerListenerTargetGroupECS` this is to match what core has done. It's required to hit performance testing requirements. 
<!-- Describe the changes in detail - the "what"-->

### Why did it change
https://govukverify.atlassian.net/wiki/spaces/DID/pages/3711140164/AWS+Fargate+Scaling+Capacity+Issues?focusedCommentId=3719233649
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking

- [OJ-1684](https://govukverify.atlassian.net/browse/OJ-1684)



[OJ-1684]: https://govukverify.atlassian.net/browse/OJ-1684?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ