### PR TITLE
IPS-493: Update post-merge workflow to use devplatform-upload-action-ecr

### DIFF
--- a/.github/workflows/post-merge-to-build.yml
+++ b/.github/workflows/post-merge-to-build.yml
@@ -14,7 +14,7 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: "0"
 
@@ -35,36 +35,16 @@ jobs:
           username: khw46367
           password: ${{ secrets.DYNATRACE_PAAS_TOKEN }}
 
-      - name: Build, tag, and push image to Amazon ECR
-        env:
-          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          ECR_REPOSITORY: ${{ secrets.BUILD_ECR_REPOSITORY }}
-        run: |
-          cd ${GITHUB_WORKSPACE} || exit 1
-          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$GITHUB_SHA .
-          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$GITHUB_SHA
-
       - name: SAM Validate
         run: sam validate --region ${{ env.AWS_REGION }} -t deploy/template.yaml
 
-      - name: Update SAM template with ECR image
-        env:
-          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          ECR_REPOSITORY: ${{ secrets.BUILD_ECR_REPOSITORY }}
-        run: |
-          cd ${GITHUB_WORKSPACE}/deploy || exit 1
-          sed -i "s|CONTAINER-IMAGE-PLACEHOLDER|$ECR_REGISTRY/$ECR_REPOSITORY:$GITHUB_SHA|" template.yaml
-
-      - name: Create template.yaml and sha zip file and upload to artifacts S3
-        run: |
-          cd ${GITHUB_WORKSPACE}/deploy || exit 1
-          sam build -t template.yaml
-          mv .aws-sam/build/template.yaml cf-template.yaml
-          zip template.zip cf-template.yaml
-
-      - name: Upload CloudFormation artifacts to S3
-        env:
-          ARTIFACT_BUCKET: ${{ secrets.BUILD_ARTIFACT_BUCKET }}
-        run: |
-          cd ${GITHUB_WORKSPACE}/deploy || exit 1
-          aws s3 cp template.zip "s3://$ARTIFACT_BUCKET/template.zip" --metadata "repository=$GITHUB_REPOSITORY,commitsha=$GITHUB_SHA"
+      - name: Deploy SAM app to ECR
+        uses: govuk-one-login/devplatform-upload-action-ecr@1.2.0
+        with:
+          artifact-bucket-name: ${{ secrets.BUILD_ARTIFACT_BUCKET }}
+          container-sign-kms-key-arn: ${{ secrets.BUILD_CONTAINER_SIGN_KMS_KEY }}
+          working-directory: .
+          docker-build-path: .
+          template-file: deploy/template.yaml
+          role-to-assume-arn: ${{ secrets.BUILD_GH_ACTIONS_ROLE_ARN }}
+          ecr-repo-name: ${{ secrets.BUILD_ECR_REPOSITORY }}

--- a/.github/workflows/post-merge-to-dev.yml
+++ b/.github/workflows/post-merge-to-dev.yml
@@ -14,7 +14,7 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: "0"
 
@@ -35,36 +35,16 @@ jobs:
           username: khw46367
           password: ${{ secrets.DYNATRACE_PAAS_TOKEN }}
 
-      - name: Build, tag, and push image to Amazon ECR
-        env:
-          DEV_ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          DEV_ECR_REPOSITORY: ${{ secrets.DEV_ECR_REPOSITORY }}
-        run: |
-          cd ${GITHUB_WORKSPACE} || exit 1
-          docker build -t $DEV_ECR_REGISTRY/$DEV_ECR_REPOSITORY:$GITHUB_SHA .
-          docker push $DEV_ECR_REGISTRY/$DEV_ECR_REPOSITORY:$GITHUB_SHA
-
       - name: SAM Validate
         run: sam validate --region ${{ env.AWS_REGION }} -t deploy/template.yaml
 
-      - name: Update SAM template with ECR image
-        env:
-          DEV_ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          DEV_ECR_REPOSITORY: ${{ secrets.DEV_ECR_REPOSITORY }}
-        run: |
-          cd ${GITHUB_WORKSPACE}/deploy || exit 1
-          sed -i "s|CONTAINER-IMAGE-PLACEHOLDER|$DEV_ECR_REGISTRY/$DEV_ECR_REPOSITORY:$GITHUB_SHA|" template.yaml
-
-      - name: Create template.yaml and sha zip file
-        run: |
-          cd ${GITHUB_WORKSPACE}/deploy || exit 1
-          sam build -t template.yaml
-          mv .aws-sam/build/template.yaml cf-template.yaml
-          zip template.zip cf-template.yaml
-
-      - name: Upload CloudFormation artifacts to S3
-        env:
-          DEV_ARTIFACT_BUCKET: ${{ secrets.DEV_ARTIFACT_BUCKET }}
-        run: |
-          cd ${GITHUB_WORKSPACE}/deploy || exit 1
-          aws s3 cp template.zip "s3://$DEV_ARTIFACT_BUCKET/template.zip" --metadata "repository=$GITHUB_REPOSITORY,commitsha=$GITHUB_SHA"
+      - name: Deploy SAM app to ECR
+        uses: govuk-one-login/devplatform-upload-action-ecr@1.2.0
+        with:
+          artifact-bucket-name: ${{ secrets.DEV_ARTIFACT_BUCKET }}
+          container-sign-kms-key-arn: ${{ secrets.DEV_CONTAINER_SIGN_KMS_KEY }}
+          working-directory: .
+          docker-build-path: .
+          template-file: deploy/template.yaml
+          role-to-assume-arn: ${{ secrets.DEV_GH_ACTIONS_ROLE_ARN }}
+          ecr-repo-name: ${{ secrets.DEV_ECR_REPOSITORY }}

--- a/.gitignore
+++ b/.gitignore
@@ -116,3 +116,6 @@ dist
 # IDE files
 .idea
 *.iml
+
+# OS generated files
+**/.DS_Store


### PR DESCRIPTION
### What changed

- Updated post-merge workflow to use devplatform-upload-action-ecr@1.2.0
- Updated .gitignore

### Why did it change

- Required for canary deployments across Identity

### Issue tracking
- [IPS-493](https://govukverify.atlassian.net/browse/IPS-493)
- [IPS-532](https://govukverify.atlassian.net/browse/IPS-532)

## Checklists

### Evidence

- Image successfully pushed, with commit tag, by manually triggering workflow (to dev):
https://github.com/govuk-one-login/ipv-cri-address-front/actions/runs/7932144855/job/21657923337

![image](https://github.com/govuk-one-login/ipv-cri-address-front/assets/153090281/137b4fce-d9d1-432f-92cf-d2c7db2b8334)

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->

- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[IPS-493]: https://govukverify.atlassian.net/browse/IPS-493?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[IPS-532]: https://govukverify.atlassian.net/browse/IPS-532?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ