### PR TITLE
CNUCD-265 Change input field type and behaviour

### DIFF
--- a/src/views/components/address-year-from-field.njk
+++ b/src/views/components/address-year-from-field.njk
@@ -7,5 +7,8 @@
   name: "addressYearFrom",
   label: { text: translate("fields.addressYearFrom.label")},
   classes: "govuk-input--width-4",
-  hint: ""
+  hint: "",
+  type:"text",
+  inputmode: "numeric",
+  attributes: { "spellcheck": "false" }
 }) }}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

This change forces the 'When did you start living here?' input field to use the `type="text"` and adds extra attributes to assist mobile users, as [documented in the Design System guidance](https://design-system.service.gov.uk/components/text-input/#:~:text=is%20a%20link.-,Numbers,-Asking%20for%20whole).

### What changed

<!-- Describe the changes in detail - the "what"-->
The nunjucks file has extra keys and values added to the `hmpoText` call.

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->
The number form field has had issues in user research.

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [CNUCD-265](https://govukverify.atlassian.net/browse/CNUCD-265)

