### PR TITLE
CNUCD: Add autocomplete to form fields

### DIFF
--- a/src/views/address/address.njk
+++ b/src/views/address/address.njk
@@ -10,15 +10,15 @@
 
 {% block mainContent %}
 
-  {% if values.checkDetailsHeader === true %}
-    <h1 id="header" class="govuk-heading-l">{{translate("pages.address-form.check-details.title")}}</h1>
+   {% if values.checkDetailsHeader === true %}
+   <h1 id="header" class="govuk-heading-l">{{translate("pages.address-form.check-details.title")}}</h1>
   {% else %}
-     <h1 id="header" class="govuk-heading-l">{{translate("pages.address-form.title")}}</h1>
+    <h1 id="header" class="govuk-heading-l">{{translate("pages.address-form.title")}}</h1>
   {% endif %}
 
   {{hmpoHtml(translate("links.changePostcode"))}}
 
-  {% call hmpoForm(ctx) %}
+  {% call hmpoForm(ctx, {autocomplete:'on'}) %}
 
     {% include "../components/address-input-fields.njk" %}
     {% include "../components/address-year-from-field.njk" %}

--- a/src/views/address/results.njk
+++ b/src/views/address/results.njk
@@ -12,7 +12,7 @@
 
   {{hmpoHtml(translate("links.changePostcode"))}}
 
-  {% call hmpoForm(ctx) %}
+  {% call hmpoForm(ctx, {autocomplete:'on'}) %}
 
     {{ hmpoSelect(ctx, {
       id: "addressResults",

--- a/src/views/address/search.njk
+++ b/src/views/address/search.njk
@@ -10,7 +10,7 @@
 {% block mainContent %}
 
   <h1 id="header" class="govuk-heading-l">{{translate("pages.addressSearch.title")}} </h1>
-  {% call hmpoForm(ctx) %}
+  {% call hmpoForm(ctx, {autocomplete:'on'}) %}
 
 {% if prepopulatedPostcode %}
 {% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
@@ -27,7 +27,8 @@
         classes: "govuk-label govuk-label--m"
       },
       classes: "govuk-!-width-one-half",
-      hint:  translate("fields.addressSearch.hint")
+      hint:  translate("fields.addressSearch.hint"),
+      autocomplete: "postal-code"
     }) }}
 
     {{ hmpoSubmit(ctx, {id: "continue", text: translate("buttons.find-address")}) }}

--- a/src/views/components/address-input-fields.njk
+++ b/src/views/components/address-input-fields.njk
@@ -30,7 +30,8 @@
   name: "addressStreetName",
   label: { text: translate("fields.addressStreetName.label") },
   classes: "govuk-input--width-20",
-  hint: ""
+  hint: "",
+  autocomplete:"address-line1"
 }) }}
 
 {{ hmpoText(ctx, {
@@ -38,5 +39,6 @@
   name: "addressLocality",
   label: { text: translate("fields.addressLocality.label") },
   classes: "govuk-input--width-20",
-  hint: ""
+  hint: "",
+  autocomplete:"address-line2"
 }) }}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

This PR allows users to use the autocomplete functionality in their web browsers to complete form fields. It adds the HMPO app feature to all `hmpoForm` calls for any future additions.

### What changed

<!-- Describe the changes in detail - the "what"-->
There is a two-step process to add autocomplete to a form. First, the `hmpoForm` call needs autocomplete to be turned on
```
{% call hmpoForm(ctx, {autocomplete:'on'}) %}
```
then individual form fields need to have [the correct autocomplete attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete) added, for example:

```
{{ hmpoText(ctx, {
  id: "addressLocality",
  name: "addressLocality",
  label: { text: translate("fields.addressLocality.label") },
  classes: "govuk-input--width-20",
  hint: "",
  autocomplete:"address-line2"
}) }}
```

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->
This change allows users who already have address information stored in their browser to recall rather than type in the information. 

The autocomplete specification for reusing address data is not ideal, as it has to deal with international addresses. Using [the MDN documentation for address autocomplete in the United Kingdom](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete#united_kingdom) gives some confidence that the chosen configuration seems to match how the data is split up in the form fields reasonably well.

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [CNUCD-260](https://govukverify.atlassian.net/browse/CNUCD-260)



[CNUCD-260]: https://govukverify.atlassian.net/browse/CNUCD-260?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ