### PR TITLE
[DFC-529] - Revert helmet import change and provide correct nonce for OPL Tracker

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -56,7 +56,7 @@ const sessionConfig = {
   ...(SESSION_TABLE_NAME && { sessionStore: dynamoDBSessionStore }),
 };
 
-const helmetConfig = commonExpress.lib.helmet;
+const helmetConfig = require("@govuk-one-login/di-ipv-cri-common-express/src/lib/helmet");
 
 const { app, router } = setup({
   config: { APP_ROOT: __dirname },

--- a/src/views/address/address.njk
+++ b/src/views/address/address.njk
@@ -29,7 +29,7 @@
   {% endcall %}
 
   {{ ga4OnPageLoad({
-    nonce: scriptNonce,
+    nonce: cspNonce,
     statusCode: '200',
     englishPageTitle: 'pages.address-form.title' | translate,
     taxonomyLevel1: 'web cri',

--- a/src/views/address/problem.njk
+++ b/src/views/address/problem.njk
@@ -11,7 +11,7 @@
   {% include "../components/address-problem-field.njk" %}
 
   {{ ga4OnPageLoad({
-    nonce: scriptNonce,
+    nonce: cspNonce,
     statusCode: '200',
     englishPageTitle: 'pages.addressProblem.title' | translate,
     taxonomyLevel1: 'web cri',

--- a/src/views/address/results.njk
+++ b/src/views/address/results.njk
@@ -29,7 +29,7 @@
   {% endcall %}
 
   {{ ga4OnPageLoad({
-    nonce: scriptNonce,
+    nonce: cspNonce,
     statusCode: '200',
     englishPageTitle: 'pages.address-results.title' | translate,
     taxonomyLevel1: 'web cri',

--- a/src/views/address/search.njk
+++ b/src/views/address/search.njk
@@ -36,7 +36,7 @@
   {% endcall %}
 
   {{ ga4OnPageLoad({
-    nonce: scriptNonce,
+    nonce: cspNonce,
     statusCode: '200',
     englishPageTitle: 'pages.addressSearch.title' | translate,
     taxonomyLevel1: 'web cri',

--- a/src/views/errors/error.njk
+++ b/src/views/errors/error.njk
@@ -4,7 +4,7 @@
 {% from "components/analytics/onPageLoad/macro.njk" import ga4OnPageLoad %}
 
 {{ ga4OnPageLoad({
-  nonce: scriptNonce,
+  nonce: cspNonce,
   statusCode: '500',
   englishPageTitle: 'error.title' | translate,
   taxonomyLevel1: 'web cri',

--- a/src/views/errors/page-not-found.njk
+++ b/src/views/errors/page-not-found.njk
@@ -4,7 +4,7 @@
 {% from "components/analytics/onPageLoad/macro.njk" import ga4OnPageLoad %}
 
 {{ ga4OnPageLoad({
-  nonce: scriptNonce,
+  nonce: cspNonce,
   statusCode: '404',
   englishPageTitle: 'pageNotFound.title' | translate,
   taxonomyLevel1: 'web cri',

--- a/src/views/previous/address.njk
+++ b/src/views/previous/address.njk
@@ -25,7 +25,7 @@
 
   {% endcall %}
   {{ ga4OnPageLoad({
-      nonce: scriptNonce,
+      nonce: cspNonce,
       statusCode: "200",
       englishPageTitle: "pages.address-form.previous.title" | translate,
       taxonomyLevel1: "web cri",

--- a/src/views/previous/problem.njk
+++ b/src/views/previous/problem.njk
@@ -10,7 +10,7 @@
 
   {% include "../components/address-problem-field.njk" %}
   {{ ga4OnPageLoad({
-    nonce: scriptNonce,
+    nonce: cspNonce,
     statusCode: '200',
     englishPageTitle: 'pages.addressProblem.title' | translate,
     taxonomyLevel1: 'web cri',

--- a/src/views/previous/results.njk
+++ b/src/views/previous/results.njk
@@ -30,7 +30,7 @@
   {% endcall %}
 
   {{ ga4OnPageLoad({
-    nonce: scriptNonce,
+    nonce: cspNonce,
     statusCode: '200',
     englishPageTitle: 'pages.address-previous-results.title' | translate,
     taxonomyLevel1: 'web cri',

--- a/src/views/previous/search.njk
+++ b/src/views/previous/search.njk
@@ -27,7 +27,7 @@
   {% endcall %}
 
   {{ ga4OnPageLoad({
-    nonce: scriptNonce,
+    nonce: cspNonce,
     statusCode: '200',
     englishPageTitle: 'pages.address-previous-search.title' | translate,
     taxonomyLevel1: 'web cri',

--- a/src/views/summary/confirm.njk
+++ b/src/views/summary/confirm.njk
@@ -158,7 +158,7 @@
 
   <br>
   {{ ga4OnPageLoad({
-    nonce: scriptNonce,
+    nonce: cspNonce,
     statusCode: '200',
     englishPageTitle: 'pages.address-confirm.title' | translate,
     taxonomy_level1: 'web cri',


### PR DESCRIPTION
## Proposed changes

### What changed

- Revert the helmet.js import change to specific the import path within the dependency
- Update the OPL trackers to use the cspNonce

### Why did it change

The change made to the helmet import within this CRI prevents the file from being passed through from common express. 

### Issue tracking

- [DFC-529](https://govukverify.atlassian.net/browse/DFC-529)

## Checklists

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed


[DFC-529]: https://govukverify.atlassian.net/browse/DFC-529?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ