### PR TITLE
SW-264: Increase log group's RetentionInDays to 30.

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -272,7 +272,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/ecs/${AWS::StackName}-AddressFront-ECS
-      RetentionInDays: 14
+      RetentionInDays: 30
 
   ECSAccessLogsGroupSubscriptionFilterCSLS:
     Type: AWS::Logs::SubscriptionFilter


### PR DESCRIPTION
Increase log group's RetentionInDays to 30. Currently any log retention that is set under 30 days will be set to 30 by a Lambda attached to the LZA Lambda run - [INCIDEN-627](https://govukverify.atlassian.net/browse/INCIDEN-627?focusedCommentId=125675)
[SW-264](https://govukverify.atlassian.net/browse/SW-264)

## Proposed changes

### What changed

- RetentionInDays: 14 to RetentionInDays: 30

### Why did it change

LZA lambda unpicks log retentions lower than 30 days.

### Issue tracking

[INCIDEN-627](https://govukverify.atlassian.net/browse/INCIDEN-627?focusedCommentId=125675)


## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->

- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[INCIDEN-627]: https://govukverify.atlassian.net/browse/INCIDEN-627?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SW-264]: https://govukverify.atlassian.net/browse/SW-264?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[INCIDEN-627]: https://govukverify.atlassian.net/browse/INCIDEN-627?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ