### PR TITLE
OJ-2535: Adds slash to paths for consistency

### DIFF
--- a/src/app/address/controllers/summary/confirm.js
+++ b/src/app/address/controllers/summary/confirm.js
@@ -111,7 +111,7 @@ class AddressConfirmController extends BaseController {
           session_id: req.session.tokenId,
           "session-id": req.session.tokenId,
           ...createPersonalDataHeaders(
-            `${API.BASE_URL}/${API.PATHS.SAVE_ADDRESS}`,
+            `${API.BASE_URL}${API.PATHS.SAVE_ADDRESS}`,
             req
           ),
         }

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -2,13 +2,13 @@ require("dotenv").config();
 
 module.exports = {
   API: {
-    BASE_URL: process.env.API_BASE_URL || "http://localhost:5007/",
+    BASE_URL: process.env.API_BASE_URL || "http://localhost:5007",
     PATHS: {
-      SESSION: "session",
-      AUTHORIZATION: "authorization",
-      POSTCODE_LOOKUP: "postcode-lookup",
-      SAVE_ADDRESS: "address",
-      GET_ADDRESSES: "addresses",
+      SESSION: "/session",
+      AUTHORIZATION: "/authorization",
+      POSTCODE_LOOKUP: "/postcode-lookup",
+      SAVE_ADDRESS: "/address",
+      GET_ADDRESSES: "/addresses",
     },
   },
   APP: {


### PR DESCRIPTION
## Proposed changes

### What changed

Adds slash to paths for consistency

### Why did it change

/ is needed in the path for `createPersonalDataHeaders` function to work

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [OJ-2535](https://govukverify.atlassian.net/browse/OJ-2535)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [x] No environment variables or secrets were added or changed



[OJ-2535]: https://govukverify.atlassian.net/browse/OJ-2535?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ