### PR TITLE
IPS-736 Orange Add named LoadBalancer fof CloudFront

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -175,6 +175,27 @@ Resources:
               - !Sub arn:aws:s3:::${AccessLogsBucket}/address-front-${Environment}/AWSLogs/${AWS::AccountId}/*
 
   # Private Application Load Balancer
+  NamedLoadBalancer:
+    Type: "AWS::ElasticLoadBalancingV2::LoadBalancer"
+    Properties:
+      Name: !Sub "${AWS::StackName}-${Environment}"
+      Scheme: internal
+      SecurityGroups:
+        - !GetAtt LoadBalancerSG.GroupId
+      Subnets:
+        - Fn::ImportValue: !Sub "${VpcStackName}-PrivateSubnetIdA"
+        - Fn::ImportValue: !Sub "${VpcStackName}-PrivateSubnetIdB"
+      Type: application
+      LoadBalancerAttributes: !If
+        - IsNotDevelopment
+        - - Key: access_logs.s3.enabled
+            Value: true
+          - Key: access_logs.s3.bucket
+            Value: !Ref AccessLogsBucket
+          - Key: access_logs.s3.prefix
+            Value: !Sub address-front-${Environment}
+        - !Ref AWS::NoValue
+
   LoadBalancer:
     Type: "AWS::ElasticLoadBalancingV2::LoadBalancer"
     Properties:
@@ -221,7 +242,7 @@ Resources:
       DefaultActions:
         - TargetGroupArn: !Ref LoadBalancerListenerTargetGroupECS
           Type: forward
-      LoadBalancerArn: !Ref LoadBalancer
+      LoadBalancerArn: !Ref NamedLoadBalancer
       Port: 80
       Protocol: HTTP
 


### PR DESCRIPTION
## Proposed changes

### What changed

Added additional named load balancer for CloudFront

### Why did it change

Existing load balancer is unnamed and the dynamic name might change which would cause a production outage from the cloudfront distribution

### Issue tracking

- [IPS-736](https://govukverify.atlassian.net/browse/IPS-736)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [X] No environment variables or secrets were added or changed

### Other considerations

- [ ] Once deployed to production the old unnamed load balancer should be removed


[IPS-736]: https://govukverify.atlassian.net/browse/IPS-736?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ