### PR TITLE
Add and enable WAF association for dev and build

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -45,6 +45,12 @@ Conditions:
     - !Equals [!Ref Environment, build]
     - !Equals [!Ref Environment, dev]
 
+  EnableCloudFront: !Or
+    - !Equals [!Ref Environment, dev]
+    - !Equals [!Ref Environment, build]
+  # - !Equals [ !Ref Environment, staging ]
+  # - !Equals [ !Ref Environment, integration ]
+
   UsePermissionsBoundary:
     Fn::Not:
       - Fn::Equals:
@@ -170,6 +176,13 @@ Resources:
               - s3:PutObject
             Resource:
               - !Sub arn:aws:s3:::${AccessLogsBucket}/address-front-${Environment}/AWSLogs/${AWS::AccountId}/*
+
+  CloudFrontWAFv2ACLAssociation:
+    Type: AWS::WAFv2::WebACLAssociation
+    Condition: EnableCloudFront
+    Properties:
+      ResourceArn: !Ref LoadBalancer
+      WebACLArn: !ImportValue cfront-origin-distrib-CloakingOriginWebACLArn
 
   # Private Application Load Balancer
   LoadBalancer:


### PR DESCRIPTION
## Proposed changes

### What changed

Enabled waf association for cloudfront testing in dev and build

### Why did it change

To enable the cloudfront distribution

### Issue tracking

- [IPS-739](https://govukverify.atlassian.net/browse/IPS-739)

## Checklists

### Environment variables or secrets

- [X] No environment variables or secrets were added or changed



[IPS-739]: https://govukverify.atlassian.net/browse/IPS-739?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ