### PR TITLE
IPS-739 enable address waf association staging and integration

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -48,8 +48,8 @@ Conditions:
   EnableCloudFront: !Or
     - !Equals [!Ref Environment, dev]
     - !Equals [!Ref Environment, build]
-  # - !Equals [ !Ref Environment, staging ]
-  # - !Equals [ !Ref Environment, integration ]
+    - !Equals [!Ref Environment, staging]
+    - !Equals [!Ref Environment, integration]
 
   UsePermissionsBoundary:
     Fn::Not:


### PR DESCRIPTION
## Proposed changes

### What changed

Enabled waf association for cloudfront  in staging and integration

### Why did it change

To enable the cloudfront distribution

### Issue tracking

- [IPS-739](https://govukverify.atlassian.net/browse/IPS-739)

## Checklists

### Environment variables or secrets

- [X] No environment variables or secrets were added or changed


[IPS-739]: https://govukverify.atlassian.net/browse/IPS-739?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ