### PR TITLE
DAC-3603-bug-fix-confirmation-ga4-on-page-load-bug-fix

### DIFF
--- a/src/views/summary/confirm.njk
+++ b/src/views/summary/confirm.njk
@@ -161,10 +161,10 @@
     nonce: cspNonce,
     statusCode: '200',
     englishPageTitle: 'pages.address-confirm.title' | translate,
-    taxonomy_level1: 'web cri',
-    taxonomy_level2: 'address',
+    taxonomyLevel1: 'web cri',
+    taxonomyLevel2: 'address',
     content_id: 'b5e5b9eb-3310-4254-ae84-3fa8a7740372',
-    logged_in_status: true,
+    loggedInStatus: true,
     dynamic: false
   }) }}
 {% endblock %}


### PR DESCRIPTION
This change fixes the on page load issue on the confirmation page - all details of the bug can be found here
https://govukverify.atlassian.net/browse/DAC-3602

## Proposed changes

### What changed

I have updated the On Page Load component attributes to use the correct keys, which enables the component to load on the page successfully.

### Why did it change

The typos meant the component were not loading

### Issue tracking

https://govukverify.atlassian.net/browse/DAC-3602

Verification of the on page load tracker functioning here - 

![Screenshot 2024-06-18 at 16 05 39](https://github.com/govuk-one-login/ipv-cri-address-front/assets/38694448/c6f75485-c5f0-4376-910a-0f989a0ef266)
