### PR TITLE
BAU: Remove cucumber publish quiet

### DIFF
--- a/test/browser/cucumber.js
+++ b/test/browser/cucumber.js
@@ -1,6 +1,5 @@
 module.exports = {
   default: {
-    publishQuiet: true,
     paths: ["./test/browser/features/**/**.feature"],
     require: [
       "./test/browser/support/**/*.js",


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Remove cucumber publish quiet

### Why did it change

It's been deprecated as per the [docs](https://github.com/cucumber/cucumber-js/blob/main/docs/deprecations.md)
