### PR TITLE
Log /addresses endpoint failures

### DIFF
--- a/src/app/address/controllers/address/prepopulate.js
+++ b/src/app/address/controllers/address/prepopulate.js
@@ -1,4 +1,5 @@
 const BaseController = require("hmpo-form-wizard").Controller;
+const logger = require("hmpo-logger").get();
 
 const {
   API: {
@@ -29,7 +30,8 @@ class AddressPrepopulateController extends BaseController {
       return super.saveValues(req, res, () => {
         callback();
       });
-    } catch (err) {
+    } catch (error) {
+      logger.warn("Error pre-populating address", error);
       callback();
     }
   }


### PR DESCRIPTION
## Proposed changes

### What changed

Log `/addresses` endpoint failures

### Why did it change

We intermittently see spikes in 4xx errors on this API call. I can find [API GW log](https://gds.splunkcloud.com/en-GB/app/gds-050-digital-Identity/search?q=search%20index%3D%22gds_di_production%22%20source%3D%22*address-cri-api-v1-175zgowlxb-private-AccessLogs*%22%7C%20spath%20status%20%7C%20search%20status%3D4*&earliest=%40w0&latest=now&display.page.search.mode=smart&dispatch.sample_ratio=1&workload_pool=&display.page.search.tab=events&display.general.type=events&display.events.timelineEarliestTime=1728237600&display.events.timelineLatestTime=1728241200&sid=1728292991.1047704)s but I cannot find API logs that seem to match.

Have added this log message to try and get more information about the error.

