### PR TITLE
OJ-2818: Feat - update address object to include country

### DIFF
--- a/src/app/address/controllers/address/manual.js
+++ b/src/app/address/controllers/address/manual.js
@@ -18,7 +18,6 @@ class AddressController extends BaseController {
         values.addressHouseName = address.buildingName;
         values.addressStreetName = address.streetName;
         values.addressLocality = address.addressLocality;
-        values.addressCountry = address.country;
 
         const yearFrom = address.validFrom
           ? new Date(address.validFrom).getFullYear()
@@ -78,7 +77,6 @@ class AddressController extends BaseController {
       addressStreetName,
       addressLocality,
       addressYearFrom,
-      addressCountry,
     } = undefined,
     chosenAddress
   ) {
@@ -95,7 +93,7 @@ class AddressController extends BaseController {
       buildingName: addressHouseName,
       streetName: addressStreetName,
       addressLocality,
-      country: addressCountry,
+      addressCountry: "GB",
       validFrom: yearFrom,
     };
 

--- a/src/app/address/controllers/address/manual.js
+++ b/src/app/address/controllers/address/manual.js
@@ -18,6 +18,7 @@ class AddressController extends BaseController {
         values.addressHouseName = address.buildingName;
         values.addressStreetName = address.streetName;
         values.addressLocality = address.addressLocality;
+        values.addressCountry = address.country;
 
         const yearFrom = address.validFrom
           ? new Date(address.validFrom).getFullYear()
@@ -77,6 +78,7 @@ class AddressController extends BaseController {
       addressStreetName,
       addressLocality,
       addressYearFrom,
+      addressCountry,
     } = undefined,
     chosenAddress
   ) {
@@ -93,12 +95,13 @@ class AddressController extends BaseController {
       buildingName: addressHouseName,
       streetName: addressStreetName,
       addressLocality,
+      country: addressCountry,
       validFrom: yearFrom,
     };
 
     const isChanged = this.checkForChanges(address, chosenAddress);
 
-    // any changed fields will be overwriten by 'address'
+    // any changed fields will be overwritten by 'address'
     // Retains all special fields (sub building name, UPRN etc)
     const updatedAddress = {
       ...chosenAddress,

--- a/src/app/address/controllers/address/manual.test.js
+++ b/src/app/address/controllers/address/manual.test.js
@@ -55,7 +55,6 @@ describe("address controller", () => {
           addressLocality: generatedAddress[0].addressLocality,
           addressYearFrom: Number(generatedAddress[0].validFrom),
           addressHouseName: generatedAddress[0].buildingName,
-          addressCountry: generatedAddress[0].country,
         })
       );
     });
@@ -91,7 +90,9 @@ describe("address controller", () => {
       expect(savedAddress.buildingName).to.equal(
         addressToSave.addressHouseName
       );
-      expect(savedAddress.country).to.equal(addressToSave.addressCountry);
+      expect(savedAddress.addressCountry).to.equal(
+        addressToSave.addressCountry
+      );
     });
 
     it("should save the address into the session - house example", async () => {
@@ -116,7 +117,9 @@ describe("address controller", () => {
       expect(savedAddress.addressLocality).to.equal(
         addressToSave.addressLocality
       );
-      expect(savedAddress.country).to.equal(addressToSave.addressCountry);
+      expect(savedAddress.addressCountry).to.equal(
+        addressToSave.addressCountry
+      );
     });
 
     it("should overwrite the current address when current address already exists", async () => {
@@ -154,7 +157,9 @@ describe("address controller", () => {
       expect(savedAddresses.addressStreetName).to.equal(
         addressToSave.streetName
       );
-      expect(savedAddresses.addressCountry).to.equal(addressToSave.country);
+      expect(savedAddresses.addressCountry).to.equal(
+        addressToSave.addressCountry
+      );
     });
 
     it("should delete the UPRN when overwriting the saved address", async () => {

--- a/src/app/address/controllers/address/manual.test.js
+++ b/src/app/address/controllers/address/manual.test.js
@@ -55,6 +55,7 @@ describe("address controller", () => {
           addressLocality: generatedAddress[0].addressLocality,
           addressYearFrom: Number(generatedAddress[0].validFrom),
           addressHouseName: generatedAddress[0].buildingName,
+          addressCountry: generatedAddress[0].country,
         })
       );
     });
@@ -67,6 +68,7 @@ describe("address controller", () => {
         addressHouseName: "My buildng name",
         addressStreetName: "street road",
         addressLocality: "small town",
+        addressCountry: "GB",
         addressYearFrom: "2022",
       };
 
@@ -89,6 +91,7 @@ describe("address controller", () => {
       expect(savedAddress.buildingName).to.equal(
         addressToSave.addressHouseName
       );
+      expect(savedAddress.country).to.equal(addressToSave.addressCountry);
     });
 
     it("should save the address into the session - house example", async () => {
@@ -96,6 +99,7 @@ describe("address controller", () => {
         addressHouseNumber: "10a",
         addressStreetName: "street road",
         addressLocality: "small town",
+        addressCountry: "GB",
         addressYearFrom: "2022",
       };
 
@@ -112,6 +116,7 @@ describe("address controller", () => {
       expect(savedAddress.addressLocality).to.equal(
         addressToSave.addressLocality
       );
+      expect(savedAddress.country).to.equal(addressToSave.addressCountry);
     });
 
     it("should overwrite the current address when current address already exists", async () => {
@@ -120,6 +125,7 @@ describe("address controller", () => {
         addressHouseName: "My building",
         addressStreetName: "avenue",
         addressLocality: "large town",
+        addressCountry: "GB",
         addressYearFrom: "2022",
       };
 
@@ -148,6 +154,7 @@ describe("address controller", () => {
       expect(savedAddresses.addressStreetName).to.equal(
         addressToSave.streetName
       );
+      expect(savedAddresses.addressCountry).to.equal(addressToSave.country);
     });
 
     it("should delete the UPRN when overwriting the saved address", async () => {
@@ -156,6 +163,7 @@ describe("address controller", () => {
         addressHouseName: "My building",
         addressStreetName: "avenue",
         addressLocality: "large town",
+        addressCountry: "GB",
         addressYearFrom: "2022",
       };
 

--- a/test/utils/addressFactory.js
+++ b/test/utils/addressFactory.js
@@ -6,7 +6,7 @@ function addressFactory(quantity) {
       streetName: "street1",
       addressLocality: "town1",
       postalCode: "postcode1",
-      country: "GB",
+      addressCountry: "GB",
       validFrom: String(new Date().getFullYear()),
     },
     {

--- a/test/utils/addressFactory.js
+++ b/test/utils/addressFactory.js
@@ -6,6 +6,7 @@ function addressFactory(quantity) {
       streetName: "street1",
       addressLocality: "town1",
       postalCode: "postcode1",
+      country: "GB",
       validFrom: String(new Date().getFullYear()),
     },
     {


### PR DESCRIPTION
## Proposed changes

### What changed

Hardcoded the value for UK addresses for `addressCountry` and updated associated unit tests 

### Why did it change

To support international addresses because the `addressCountry` field will be made mandatory in the backend and currently its defaulted to "GB".

### Evidence


https://github.com/user-attachments/assets/5a2f6a1d-d9f6-46ff-a2a0-15e7cb91aef4



### Issue tracking

- [OJ-2818](https://govukverify.atlassian.net/browse/OJ-2818)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [x] No environment variables or secrets were added or changed

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[OJ-2818]: https://govukverify.atlassian.net/browse/OJ-2818?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ