### PR TITLE
OJ-2818: Chore - to check the form doesn’t contain the country the va…

### DIFF
--- a/src/app/address/controllers/address/manual.test.js
+++ b/src/app/address/controllers/address/manual.test.js
@@ -67,7 +67,6 @@ describe("address controller", () => {
         addressHouseName: "My buildng name",
         addressStreetName: "street road",
         addressLocality: "small town",
-        addressCountry: "GB",
         addressYearFrom: "2022",
       };
 
@@ -90,9 +89,8 @@ describe("address controller", () => {
       expect(savedAddress.buildingName).to.equal(
         addressToSave.addressHouseName
       );
-      expect(savedAddress.addressCountry).to.equal(
-        addressToSave.addressCountry
-      );
+      expect(savedAddress.addressCountry).to.equal("GB");
+      expect(addressToSave.addressCountry).to.be.undefined;
     });
 
     it("should save the address into the session - house example", async () => {
@@ -100,7 +98,6 @@ describe("address controller", () => {
         addressHouseNumber: "10a",
         addressStreetName: "street road",
         addressLocality: "small town",
-        addressCountry: "GB",
         addressYearFrom: "2022",
       };
 
@@ -117,9 +114,8 @@ describe("address controller", () => {
       expect(savedAddress.addressLocality).to.equal(
         addressToSave.addressLocality
       );
-      expect(savedAddress.addressCountry).to.equal(
-        addressToSave.addressCountry
-      );
+      expect(savedAddress.addressCountry).to.equal("GB");
+      expect(addressToSave.addressCountry).to.be.undefined;
     });
 
     it("should overwrite the current address when current address already exists", async () => {
@@ -128,7 +124,6 @@ describe("address controller", () => {
         addressHouseName: "My building",
         addressStreetName: "avenue",
         addressLocality: "large town",
-        addressCountry: "GB",
         addressYearFrom: "2022",
       };
 
@@ -157,9 +152,8 @@ describe("address controller", () => {
       expect(savedAddresses.addressStreetName).to.equal(
         addressToSave.streetName
       );
-      expect(savedAddresses.addressCountry).to.equal(
-        addressToSave.addressCountry
-      );
+      expect(savedAddresses.addressCountry).to.equal("GB");
+      expect(addressToSave.addressCountry).to.be.undefined;
     });
 
     it("should delete the UPRN when overwriting the saved address", async () => {
@@ -168,7 +162,6 @@ describe("address controller", () => {
         addressHouseName: "My building",
         addressStreetName: "avenue",
         addressLocality: "large town",
-        addressCountry: "GB",
         addressYearFrom: "2022",
       };
 

--- a/test/mocks/mappings/addresses.json
+++ b/test/mocks/mappings/addresses.json
@@ -51,8 +51,7 @@
             "uprn": "000",
             "buildingName": "EAST ZZZ",
             "addressLocality": "BEAMINSTER",
-            "postalCode": "ZZ1 1ZZ",
-            "addressCountry": "GB"
+            "postalCode": "ZZ1 1ZZ"
           },
           {
             "uprn": "111",
@@ -61,8 +60,7 @@
             "streetName": "ZZZ WAY",
             "dependentAddressLocality": "WHITEHOUSE",
             "addressLocality": "MILTON KEYNES",
-            "postalCode": "ZZ1 1ZZ",
-            "addressCountry": "GB"
+            "postalCode": "ZZ1 1ZZ"
           },
           {
             "subBuildingName": "FLAT 11",
@@ -77,8 +75,7 @@
             "streetName": "ZZZ ROAD",
             "dependentAddressLocality": "LONG ZZZ",
             "addressLocality": "NOTTINGHAM",
-            "postalCode": "ZZ1 1ZZ",
-            "addressCountry": "GB"
+            "postalCode": "ZZ1 1ZZ"
           },
           {
             "uprn": "333",
@@ -91,8 +88,7 @@
             "doubleDependentAddressLocality": "SOME ZZZ",
             "dependentAddressLocality": "LONG EATON",
             "addressLocality": "GREAT MISSENDEN",
-            "postalCode": "ZZ1 1ZZ",
-            "addressCountry": "GB"
+            "postalCode": "ZZ1 1ZZ"
           },
           {
             "buildingName": "R103",
@@ -100,8 +96,7 @@
             "streetName": "CREEK ROAD",
             "doubleDependentAddressLocality": "",
             "addressLocality": "ZZZ ISLAND",
-            "postalCode": "ZZ1 1ZZ",
-            "addressCountry": "GB"
+            "postalCode": "ZZ1 1ZZ"
           },
           {
             "uprn": "444",
@@ -109,16 +104,14 @@
             "streetName": "ZZZ CRESCENT",
             "dependentAddressLocality": "NEW PITSLIGO",
             "addressLocality": "FRASERBURGH",
-            "postalCode": "ZZ1 1ZZ",
-            "addressCountry": "GB"
+            "postalCode": "ZZ1 1ZZ"
           },
           {
             "uprn": "555",
             "buildingNumber": "3",
             "streetName": "ZZZ WALK",
             "addressLocality": "MIDDLESBROUGH",
-            "postalCode": "ZZ1 1ZZ",
-            "addressCountry": "GB"
+            "postalCode": "ZZ1 1ZZ"
           }
         ]
       }


### PR DESCRIPTION
## Proposed changes

### What changed

Updated the unit tests and the address.json in the mocks to remove `addressCountry` in the json as it mimics the form data. `addressToSave` is passed in the request without the country - the controller processes the request and when we get `savedAddress` from the session that should have the country value included

### Why did it change

Instead we want to verify the hardcoded country value is only coming from the controller, if the value in the controller changes it should break associated tests. At the moment changed controller value will pass existing tests as it's hardcoded in the json.

### Issue tracking

- [OJ-2818](https://govukverify.atlassian.net/browse/OJ-2818)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->

- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[OJ-2818]: https://govukverify.atlassian.net/browse/OJ-2818?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ