### PR TITLE
OJ-2833: Only make pre-population call if we have a session (part 1)

### DIFF
--- a/src/app/address/controllers/address/prepopulate.js
+++ b/src/app/address/controllers/address/prepopulate.js
@@ -12,6 +12,11 @@ class AddressPrepopulateController extends BaseController {
     req.session.prepopulatedPostcode = false;
 
     try {
+      if (!req.session.tokenId) {
+        logger.warn("No session ID, not attempting pre-population");
+        return callback();
+      }
+
       const prepopulatedAddresses = await req.axios.get(`${GET_ADDRESSES}`, {
         headers: {
           session_id: req.session.tokenId,

--- a/src/app/address/controllers/address/prepopulate.test.js
+++ b/src/app/address/controllers/address/prepopulate.test.js
@@ -47,6 +47,16 @@ describe("Prepopulate controller", () => {
       });
     });
 
+    it("should not retrieve addresses if there is no session", async () => {
+      await prepopulateController.saveValues(
+        { ...req, session: {} },
+        res,
+        next
+      );
+
+      expect(req.axios.get).to.have.callCount(0);
+    });
+
     context("on success", () => {
       let prototypeSpy;
 

--- a/src/app/address/controllers/address/search.js
+++ b/src/app/address/controllers/address/search.js
@@ -1,5 +1,5 @@
 const BaseController = require("hmpo-form-wizard").Controller;
-
+const logger = require("hmpo-logger").get();
 const { API } = require("../../../../lib/config");
 const {
   createPersonalDataHeaders,
@@ -28,7 +28,9 @@ class AddressSearchController extends BaseController {
         req.sessionModel.set("addressPostcode", addressPostcode);
         callback();
       });
-    } catch (err) {
+    } catch (error) {
+      logger.warn("Error searching for address", error);
+
       req.sessionModel.set("requestIsSuccessful", false);
       req.sessionModel.set("checkDetailsHeader", false);
       req.sessionModel.set("addressPostcode", addressPostcode);

--- a/src/app/address/controllers/summary/confirm.js
+++ b/src/app/address/controllers/summary/confirm.js
@@ -1,5 +1,5 @@
 const BaseController = require("hmpo-form-wizard").Controller;
-
+const logger = require("hmpo-logger").get();
 const {
   generateHTMLofAddress,
 } = require("../../../../presenters/addressPresenter");
@@ -99,8 +99,10 @@ class AddressConfirmController extends BaseController {
           callback();
         });
       }
-    } catch (err) {
-      callback(err);
+    } catch (error) {
+      logger.warn("Error submitting address", error);
+
+      callback(error);
     }
   }
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

1. Add warn logging to errors for other API calls
2. Only make pre-population call if we have a session (part 1 of the ticket) 

### Why did it change

We have an ongoing incident around the levels of errors being thrown by the /addresses endpoint. This PR makes sure we don't make calls that we know are going to fail, part 2 of the ticket is to stop people accessing the page incorrectly.

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [OJ-2833](https://govukverify.atlassian.net/browse/OJ-2833)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [x] No environment variables or secrets were added or changed



[OJ-2833]: https://govukverify.atlassian.net/browse/OJ-2833?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ