### PR TITLE
OJ-2882: Change within three month question to specify UK address

### DIFF
--- a/src/app/address/controllers/summary/confirm.js
+++ b/src/app/address/controllers/summary/confirm.js
@@ -59,7 +59,7 @@ class AddressConfirmController extends BaseController {
 
     // if we need more info and a previou address does not exist, add validation
     if (isMoreInfoRequired && !previousAddress) {
-      formFields.isAddressMoreThanThreeMonths?.validate.push({
+      formFields.hasPreviousUKAddressWithinThreeMonths?.validate.push({
         fn: confirmationValidation,
         arguments: [],
       });
@@ -70,9 +70,9 @@ class AddressConfirmController extends BaseController {
 
   async saveValues(req, res, callback) {
     try {
-      const isAddressMoreThanThreeMonths =
-        req.form.values.isAddressMoreThanThreeMonths;
-      if (isAddressMoreThanThreeMonths === "lessThanThreeMonths") {
+      const hasPreviousUKAddressWithinThreeMonths =
+        req.form.values.hasPreviousUKAddressWithinThreeMonths;
+      if (hasPreviousUKAddressWithinThreeMonths === "yes") {
         // reset variables specific to current address journey
         req.sessionModel.set("addPreviousAddresses", true);
         callback();

--- a/src/app/address/controllers/summary/confirm.test.js
+++ b/src/app/address/controllers/summary/confirm.test.js
@@ -89,8 +89,8 @@ describe("Address confirmation controller", () => {
       expect(next).to.have.been.calledWith();
     });
 
-    it("Should reset journey wide variables and enter previous journey when more information is required", async () => {
-      req.form.values.isAddressMoreThanThreeMonths = "lessThanThreeMonths";
+    it("Should reset journey wide variables and enter previous journey when user has previous UK address within 3 months", async () => {
+      req.form.values.hasPreviousUKAddressWithinThreeMonths = "yes";
       await addressConfirm.saveValues(req, res, next);
       expect(req.session.test.addPreviousAddresses).to.equal(true);
     });

--- a/src/app/address/routes/summary/fields.js
+++ b/src/app/address/routes/summary/fields.js
@@ -11,9 +11,9 @@ module.exports = {
     journeyKey: "addresses",
     default: [],
   },
-  isAddressMoreThanThreeMonths: {
+  hasPreviousUKAddressWithinThreeMonths: {
     type: "radios",
-    items: ["moreThanThreeMonths", "lessThanThreeMonths"],
+    items: ["yes", "no"],
     validate: [], // custom validator in addressConfirm.js
   },
 };

--- a/src/app/address/routes/summary/steps.js
+++ b/src/app/address/routes/summary/steps.js
@@ -6,7 +6,7 @@ module.exports = {
     entryPoint: true,
     fields: [
       "addPrevious",
-      "isAddressMoreThanThreeMonths",
+      "hasPreviousUKAddressWithinThreeMonths",
       "currentAddress",
       "previousAddress",
     ],

--- a/src/locales/cy/fields.yml
+++ b/src/locales/cy/fields.yml
@@ -69,19 +69,19 @@ addressBreak:
       label: "Ceisiwch roi eich cod post i mewn eto"
       hint: ""
       reveal: ""
-isAddressMoreThanThreeMonths:
-  label: "Ydych chi wedi wedi byw yma am fwy na 3 mis?"
-  hint: "Byddwn angen gofyn i chi ble roeddech chi'n byw o'r blaen os ydych chi wedi symud i'r cyfeiriad hwn yn ddiweddar."
+hasPreviousUKAddressWithinThreeMonths:
+  label: "Ydych chi wedi byw mewn cyfeiriad arall yn y DU yn ystod y 3 blynedd diwethaf?"
+  hint: "Efallai y byddwn yn gofyn i chi am eich cyfeiriad blaenorol."
   items:
-    moreThanThreeMonths:
+    yes:
       label: "Ydw"
       value: "Ydw"
       hint: ""
       reveal: ""
-    lessThanThreeMonths:
+    no:
       label: "Na"
       value: "Na"
       hint: ""
       reveal: ""
   validation:
-    confirmationValidation: "Dewiswch ydw os ydych chi wedi byw yn y cyfeiriad hwn am fwy na 3 mis"
+    confirmationValidation: "Dewiswch ydw os ydych chi wedi byw mewn cyfeiriad arall yn y DU yn ystod y 3 blynedd diwethaf"

--- a/src/locales/en/fields.yml
+++ b/src/locales/en/fields.yml
@@ -81,19 +81,19 @@ addressBreak:
       hint: ""
       reveal: ""
 
-isAddressMoreThanThreeMonths:
-  label: Have you lived here for more than 3 months?
-  hint: We'll need to ask you where you lived before if you've recently moved to this address.
+hasPreviousUKAddressWithinThreeMonths:
+  label: Have you lived at another UK address in the past 3 months?
+  hint: We may need to ask for your previous address.
   items:
-    moreThanThreeMonths:
+    yes:
       label: "Yes"
       value: "Yes"
       hint: ""
       reveal: ""
-    lessThanThreeMonths:
+    no:
       label: "No"
       value: "No"
       hint: ""
       reveal: ""
   validation:
-    confirmationValidation: Select yes if you've lived at this address for more than 3 months
+    confirmationValidation: Select yes if you’ve lived at another UK address in the past three months.

--- a/src/views/summary/confirm.njk
+++ b/src/views/summary/confirm.njk
@@ -132,9 +132,9 @@
     {% if isMoreInfoRequired %}
 
       {{ hmpoRadios(ctx, {
-        id: "isAddressMoreThanThreeMonths",
-        name: "isAddressMoreThanThreeMonths",
-        value: "isAddressMoreThanThreeMonths",
+        id: "hasPreviousUKAddressWithinThreeMonths",
+        name: "hasPreviousUKAddressWithinThreeMonths",
+        value: "hasPreviousUKAddressWithinThreeMonths",
         inline: true,
         attributes: {
           "data-id": "getPreviousAddressRadios"
@@ -142,8 +142,8 @@
         label: {
           classes: ["govuk-fieldset__legend--s"]
         },
-        legend: translate("fields.isAddressMoreThanThreeMonths.label"),
-        fields: isAddressMoreThanThreeMonths.items
+        legend: translate("fields.hasPreviousUKAddressWithinThreeMonths.label"),
+        fields: hasPreviousUKAddressWithinThreeMonths.items
       }) }}
 
     {% endif %}

--- a/test/browser/features/address-confirm.feature
+++ b/test/browser/features/address-confirm.feature
@@ -30,7 +30,7 @@ Feature: Happy Path - confirming address details
       Then they should see the confirm page
       And they should see the previous address modal
       When they confirm their details
-      Then they should see an error message "more than 3 months"
+      Then they should see an error message "Select yes if you’ve lived at another UK address in the past three months."
 
     Scenario: Selecting less than 3 months residence should move the user to the previous address journey
       Given they are on the address page
@@ -38,7 +38,7 @@ Feature: Happy Path - confirming address details
       And they continue to confirm address
       Then they should see the confirm page
       And they should see the previous address modal
-      When they select the less than three months radio button
+      When they select the previous UK address within three months radio button
       And they confirm their details
       Then they should see the previous address search page
 

--- a/test/browser/features/address-manual-empty-previous.feature
+++ b/test/browser/features/address-manual-empty-previous.feature
@@ -9,7 +9,7 @@ Feature: Happy Path - confirming manual address details - previous
     Then they have selected an address ""
     When they add their residency date with a "recent" move year
     And they continue to confirm address
-    And they select the less than three months radio button
+    And they select the previous UK address within three months radio button
     And they confirm their details
     And they searched for their postcode "E1 8QS"
     Then they should see the results page

--- a/test/browser/features/address-manual-preselected-previous.feature
+++ b/test/browser/features/address-manual-preselected-previous.feature
@@ -9,7 +9,7 @@ Feature: Happy Path - confirming preselected address details and date invalidati
     Then they have selected an address ""
     When they add their residency date with a "recent" move year
     And they continue to confirm address
-    And they select the less than three months radio button
+    And they select the previous UK address within three months radio button
     And they confirm their details
     And they searched for their postcode "E1 8QS"
     Then they should see the results page

--- a/test/browser/features/address-results-previous.feature
+++ b/test/browser/features/address-results-previous.feature
@@ -9,7 +9,7 @@ Feature: Happy Path - confirming preselected address details and date invalidati
     Then they have selected an address ""
     When they add their residency date with a "recent" move year
     And they continue to confirm address
-    And they select the less than three months radio button
+    And they select the previous UK address within three months radio button
     And they confirm their details
     And they searched for their postcode "E1 8QS"
     Then they should see the results page

--- a/test/browser/features/address-search-previous.feature
+++ b/test/browser/features/address-search-previous.feature
@@ -9,7 +9,7 @@ Feature: Happy Path - previous
       Then they have selected an address "10 WHITECHAPEL HIGH STREET, LONDON, E1 8QS"
       When they add their residency date with a "recent" move year
       And they continue to confirm address
-      And they select the less than three months radio button
+      And they select the previous UK address within three months radio button
       And they confirm their details
 
     Scenario: Previous address - Searching and successfully returning a postcode and saving a single address

--- a/test/browser/pages/confirm.js
+++ b/test/browser/pages/confirm.js
@@ -25,22 +25,24 @@ module.exports = class PlaywrightDevPage {
 
   async selectNoRadioButton() {
     await this.page
-      .locator("#isAddressMoreThanThreeMonths-lessThanThreeMonths")
+      .locator("#hasPreviousUKAddressWithinThreeMonths-no")
       .click();
   }
 
   async returnRadioLegend() {
     return this.page.textContent(
-      "#isAddressMoreThanThreeMonths-fieldset > legend"
+      "#hasPreviousUKAddressWithinThreeMonths-fieldset > legend"
     );
   }
 
   isAddressRadioButtonPresent() {
-    return this.page.locator("#isAddressMoreThanThreeMonths").isVisible();
+    return this.page
+      .locator("#hasPreviousUKAddressWithinThreeMonths")
+      .isVisible();
   }
 
   async selectYesRadioButton() {
-    await this.page.locator("#isAddressMoreThanThreeMonths").click();
+    await this.page.locator("#hasPreviousUKAddressWithinThreeMonths").click();
   }
 
   isCurrentPage() {

--- a/test/browser/step_definitions/confirm.js
+++ b/test/browser/step_definitions/confirm.js
@@ -30,9 +30,9 @@ Then(
   async function (value) {
     const confirmPage = new ConfirmPage(this.page);
     if (value === ">3") {
-      await confirmPage.selectYesRadioButton();
-    } else {
       await confirmPage.selectNoRadioButton();
+    } else {
+      await confirmPage.selectYesRadioButton();
     }
   }
 );
@@ -59,7 +59,7 @@ Then("they should see the year value {string}", async function (value) {
 Then("they should see the previous address modal", async function () {
   const confirmPage = new ConfirmPage(this.page);
   const radioLegendTitle = await confirmPage.returnRadioLegend();
-  expect(radioLegendTitle).to.include("more than 3 months");
+  expect(radioLegendTitle).to.include("in the past 3 months");
 });
 
 Then("they should not see the previous address modal", async function () {
@@ -89,7 +89,10 @@ When("they confirm their details", async function () {
   await confirmPage.confirmDetails();
 });
 
-When("they select the less than three months radio button", async function () {
-  const confirmPage = new ConfirmPage(this.page);
-  await confirmPage.selectNoRadioButton();
-});
+When(
+  "they select the previous UK address within three months radio button",
+  async function () {
+    const confirmPage = new ConfirmPage(this.page);
+    await confirmPage.selectYesRadioButton();
+  }
+);


### PR DESCRIPTION
## Proposed changes

### What changed

Rename isAddressMoreThanThreeMonths to hasPreviousUKAddressWithinThreeMonths to reflect change to input text.

Update hasPreviousUKAddressWithinThreeMonths text fields to specify the previous Address needs to be in the UK.

Flip the logic of the hasPreviousUKAddressWithinThreeMonths radio buttons.
- Yes now requires the user to go through adding a previous address
- No will now take you forward to the VC.

### Why did it change

For UK users we need to collect at least 3 months worth of addresses. If a user has moved to the UK within the last 3 months, we do not need to collect another address.

### Issue tracking

- [OJ-2882](https://govukverify.atlassian.net/browse/OJ-2882)

### Evidence

![image](https://github.com/user-attachments/assets/5ab47ed5-5380-46da-9e32-52499087cefc)
![image](https://github.com/user-attachments/assets/041b3ac8-803b-4896-9b15-287807b86911)

[OJ-2882]: https://govukverify.atlassian.net/browse/OJ-2882?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ