### PR TITLE
build: bump govuk-frontend to version 4.9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "express": "4.21.1",
     "express-async-errors": "3.1.1",
     "express-session": "1.18.1",
-    "govuk-frontend": "4.8.0",
+    "govuk-frontend": "4.9.0",
     "hmpo-app": "3.0.1",
     "hmpo-components": "6.4.0",
     "hmpo-config": "2.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3724,10 +3724,10 @@ got@<12:
     p-cancelable "^2.0.0"
     responselike "^2.0.0"
 
-govuk-frontend@4.8.0:
-  version "4.8.0"
-  resolved "https://registry.yarnpkg.com/govuk-frontend/-/govuk-frontend-4.8.0.tgz#df4e56c762e93aae74fed214bb6be08e13783772"
-  integrity sha512-NOmPJxL8IYq1HSNHYKx9XY2LLTxuwb+IFASiGQO4sgJ8K7AG66SlSeqARrcetevV8zOf+i1z+MbJJ2O7//OxAw==
+govuk-frontend@4.9.0:
+  version "4.9.0"
+  resolved "https://registry.yarnpkg.com/govuk-frontend/-/govuk-frontend-4.9.0.tgz#a09068130fa087e67de25956940cb8280a364372"
+  integrity sha512-zfX+GBUKpWBeV6JwCIawEuI8VRWlskH8Ok8aNUjKOvzo3zIaNbcrv4IOwgy+oSnMoGh67Eeh+vb7+9GFxN2fNg==
 
 graceful-fs@^4.1.15, graceful-fs@^4.1.2:
   version "4.2.11"


### PR DESCRIPTION
## Proposed changes

### What changed

Bump govuk-frontend to version 4.9.0

### Why did it change
There have been changes to crown logo.

### Issue tracking
- [OJ-2914](https://govukverify.atlassian.net/browse/OJ-2914)


[OJ-2914]: https://govukverify.atlassian.net/browse/OJ-2914?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ