### PR TITLE
Turn off UA as it is no longer being used

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -364,7 +364,7 @@ Resources:
             - Name: GA4_ENABLED
               Value: true
             - Name: UA_ENABLED
-              Value: true
+              Value: false
             - Name: ANALYTICS_COOKIE_DOMAIN
               Value:
                 !If [


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Turn off UA as it is no longer being used.

There will be subsequent tickets to deprecate but this is just to turn off as it causes a console error with new versions of the `@govuk-one-login/frontend-analytics` package.

![image](https://github.com/user-attachments/assets/484e81c5-5741-48bb-bb2d-729ad421f6cb)
