### PR TITLE
OJ-2912: Fix - update content on address screen

### DIFF
--- a/src/locales/en/fields.yml
+++ b/src/locales/en/fields.yml
@@ -39,9 +39,9 @@ addressLocality:
     maxlength: Check you've entered your town or city correctly
 
 addressYearFrom:
-  title: When did you start living here?
+  title: When did you start living at this address?
   classes: govuk-input--width-4
-  label: Enter the year you started living at this address, for example 2017
+  label: Enter the year you started living here, for example 2017
   validation:
     default: Enter the year using only 4 digits
     isPreviousDate: The date you started living at this address must be in the past


### PR DESCRIPTION

## Proposed changes

### What changed

- Updated `When did you start living here?` to `When did you start living at this address?` title
- Updated `Enter the year you started living at this address, for example 2017` to `Enter the year you started living here, for example 2017` hint text

Changes has been made below:
<img width="951" alt="Screenshot 2024-12-04 at 16 13 43" src="https://github.com/user-attachments/assets/06a49740-447b-44f5-9cf5-80ab626886b7">


### Why did it change

To make it consistent with the International Address screens

### Issue tracking

- [OJ-2912](https://govukverify.atlassian.net/browse/OJ-2912)

## Checklists

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed



[OJ-2912]: https://govukverify.atlassian.net/browse/OJ-2912?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ