### PR TITLE
OJ-2913: Confirm page - make summary list keys bold

### DIFF
--- a/src/assets/scss/application.scss
+++ b/src/assets/scss/application.scss
@@ -1,4 +1,5 @@
 $govuk-assets-path: "/public/";
+$hmpo-summary-list: false;
 
 @import "../../../node_modules/govuk-frontend/govuk/all";
 @import "../../../node_modules/hmpo-components/all";


### PR DESCRIPTION
## Proposed changes

### What changed

Looks to be a clash with the hmpo styling on summary lists causing them not to bold the keys, which should be default when using govuk summary-list.

Disable hmpo summary list sylying by setting css variable `$hmpo-summary-list: false;` (https://github.com/HMPO/hmpo-components/blob/master/README.md?plain=1#L282)

### Why did it change

This ensures that the styling matches the expected design and improves readability.

### Issue tracking

Note: This only covers 1 of the AC's for the ticket, the other will be in another PR.
- [OJ-2913](https://govukverify.atlassian.net/browse/OJ-2913)

### Evidence

<img width="742" alt="image" src="https://github.com/user-attachments/assets/0f453152-9a90-46fd-ab91-0daf4c4f8eff">


[OJ-2913]: https://govukverify.atlassian.net/browse/OJ-2913?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ