### PR TITLE
OJ-2913: Title case address return from a post code search

### DIFF
--- a/src/app/address/controllers/address/search.js
+++ b/src/app/address/controllers/address/search.js
@@ -60,8 +60,26 @@ class AddressSearchController extends BaseController {
       }
     );
     const addresses = addressResults.data;
+    return this.titleCaseAddresses(addresses);
+  }
 
-    return addresses;
+  titleCaseAddresses(addresses) {
+    const titleCasedAddresses = addresses.map((address) => {
+      const tempAddress = {};
+      for (let key in address) {
+        if (typeof address[key] === "string" && key !== "postalCode") {
+          tempAddress[key] = address[key].replace(
+            /\w\S*/g,
+            (text) =>
+              text.charAt(0).toUpperCase() + text.substring(1).toLowerCase()
+          );
+        } else {
+          tempAddress[key] = address[key];
+        }
+      }
+      return tempAddress;
+    });
+    return titleCasedAddresses;
   }
 }
 

--- a/src/app/address/controllers/address/search.test.js
+++ b/src/app/address/controllers/address/search.test.js
@@ -84,8 +84,8 @@ describe("Address Search controller", function () {
         expect(req.sessionModel.get("requestIsSuccessful")).to.be.true;
       });
       it("should set searchResults", () => {
-        expect(req.sessionModel.get("searchResults")).to.equal(
-          testData.apiResponse.data
+        expect(req.sessionModel.get("searchResults")).to.deep.equal(
+          testData.titleCasedAddresses
         );
       });
       it("should set addressPostcode", () => {
@@ -121,6 +121,52 @@ describe("Address Search controller", function () {
       it("should call callback without an error", () => {
         expect(next).to.have.been.calledOnceWithExactly();
       });
+    });
+  });
+
+  describe("titleCaseAddresses", () => {
+    it("should title case addresses", () => {
+      const returnedAddresses = addressSearch.titleCaseAddresses(
+        testData.apiResponse.data
+      );
+      expect(returnedAddresses).to.deep.equal(testData.titleCasedAddresses);
+    });
+
+    it("should not title case postalCode fields", () => {
+      const addresses = [
+        {
+          postalCode: "PoSt cOde",
+        },
+        {
+          postalCode: "PO51 CDE",
+        },
+        {
+          postalCode: "po51 cde",
+        },
+      ];
+      const returnedAddresses = addressSearch.titleCaseAddresses(addresses);
+      expect(returnedAddresses).to.deep.equal(addresses);
+    });
+
+    it("should return empty array if addresses is empty", () => {
+      const returnedAddresses = addressSearch.titleCaseAddresses([]);
+      expect(returnedAddresses).to.deep.equal([]);
+    });
+
+    it("should not attempt to title case null fields", () => {
+      const returnedAddresses = addressSearch.titleCaseAddresses([
+        { buildingName: null },
+      ]);
+      expect(returnedAddresses).to.deep.equal([{ buildingName: null }]);
+    });
+
+    it("should not attempt to title case non string fields", () => {
+      const returnedAddresses = addressSearch.titleCaseAddresses([
+        { buildingNumber: 1, booleanField: true },
+      ]);
+      expect(returnedAddresses).to.deep.equal([
+        { buildingNumber: 1, booleanField: true },
+      ]);
     });
   });
 });

--- a/test/browser/features/address-manual-preselected-previous.feature
+++ b/test/browser/features/address-manual-preselected-previous.feature
@@ -13,14 +13,14 @@ Feature: Happy Path - confirming preselected address details and date invalidati
     And they confirm their details
     And they searched for their postcode "E1 8QS"
     Then they should see the results page
-    And they have selected an address "1 WHITECHAPEL HIGH STREET, LONDON, E1 8QS"
+    And they have selected an address "1 Whitechapel High Street, London, E1 8QS"
     Then they should see the address page
 
     Scenario: Changing address values and successfully passing validation when a previous date is added
       Given they are on the address page
       Then they should see the postcode prefilled with "E1 8QS"
       And they should see house number prefilled with "1"
-      And they should see street prefilled with "WHITECHAPEL HIGH STREET"
-      And they should see town or city prefilled with "LONDON"
+      And they should see street prefilled with "Whitechapel High Street"
+      And they should see town or city prefilled with "London"
       When they continue to confirm address
       Then they should see the confirm page

--- a/test/browser/features/address-manual-preselected.feature
+++ b/test/browser/features/address-manual-preselected.feature
@@ -14,8 +14,8 @@ Feature: Happy Path - confirming preselected address details and date invalidati
       Given they are on the address page
       Then they should see the postcode prefilled with "E1 8QS"
       Then they should see house number prefilled with "10"
-      And they should see street prefilled with "WHITECHAPEL HIGH STREET"
-      And they should see town or city prefilled with "LONDON"
+      And they should see street prefilled with "Whitechapel High Street"
+      And they should see town or city prefilled with "London"
       When they add their residency date with a "recent" move year
       And they continue to confirm address
       Then they should see the confirm page

--- a/test/browser/features/address-manual-rfc-0020-address-structure-compliance.feature
+++ b/test/browser/features/address-manual-rfc-0020-address-structure-compliance.feature
@@ -8,126 +8,126 @@ Feature: compliance for address structures presented in https://github.com/alpha
 
   Scenario: Show sub building name as flat number
     Then they should see the results page
-    And they have selected an address "FLAT 1 87 ZZZ WAY, WHITEHOUSE MILTON KEYNES, ZZ1 1ZZ"
+    And they have selected an address "Flat 1 87 Zzz Way, Whitehouse Milton Keynes, ZZ1 1ZZ"
     Then they should see the address page
     And they should see the postcode prefilled with "ZZ1 1ZZ"
-    And they should see flat number prefilled with "FLAT 1"
+    And they should see flat number prefilled with "Flat 1"
     And they should see house number prefilled with "87"
-    And they should see street prefilled with "ZZZ WAY"
-    And they should see town or city prefilled with "MILTON KEYNES"
+    And they should see street prefilled with "Zzz Way"
+    And they should see town or city prefilled with "Milton Keynes"
     When they add their residency date with a "recent" move year
     And they continue to confirm address
     Then they should see the confirm page
-    And they should see the address value "FLAT 1"
-    And they should see the address value "87 ZZZ WAY,"
-    And they should see the address value "WHITEHOUSE MILTON KEYNES,"
+    And they should see the address value "Flat 1"
+    And they should see the address value "87 Zzz Way,"
+    And they should see the address value "Whitehouse Milton Keynes,"
     And they should see the address value "ZZ1 1ZZ"
 
 
   Scenario: Show building name as house name
     Then they should see the results page
-    And they have selected an address "FLAT 11 BLASHFORD ZZZ ROAD, LONDON, ZZ1 1ZZ"
+    And they have selected an address "Flat 11 Blashford Zzz Road, London, ZZ1 1ZZ"
     Then they should see the address page
     And they should see the postcode prefilled with "ZZ1 1ZZ"
-    And they should see flat number prefilled with "FLAT 11"
+    And they should see flat number prefilled with "Flat 11"
     And they should see house number prefilled with ""
-    And they should see house name prefilled with "BLASHFORD"
-    And they should see street prefilled with "ZZZ ROAD"
-    And they should see town or city prefilled with "LONDON"
+    And they should see house name prefilled with "Blashford"
+    And they should see street prefilled with "Zzz Road"
+    And they should see town or city prefilled with "London"
     When they add their residency date with a "recent" move year
     And they continue to confirm address
     Then they should see the confirm page
-    And they should see the address value "FLAT 11 BLASHFORD<br>ZZZ ROAD"
-    And they should see the address value "LONDON,"
+    And they should see the address value "Flat 11 Blashford<br>Zzz Road"
+    And they should see the address value "London,"
     And they should see the address value "ZZ1 1ZZ"
 
   Scenario: Show neither flat number nor house number
     Then they should see the results page
-    And they have selected an address "ZZZ MARINA ZZZ ROAD, LONG ZZZ NOTTINGHAM, ZZ1 1ZZ"
+    And they have selected an address "Zzz Marina Zzz Road, Long Zzz Nottingham, ZZ1 1ZZ"
     Then they should see the address page
     And they should see the postcode prefilled with "ZZ1 1ZZ"
     And they should see flat number prefilled with ""
     And they should see house number prefilled with ""
-    And they should see house name prefilled with "ZZZ MARINA"
-    And they should see street prefilled with "ZZZ ROAD"
-    And they should see town or city prefilled with "NOTTINGHAM"
+    And they should see house name prefilled with "Zzz Marina"
+    And they should see street prefilled with "Zzz Road"
+    And they should see town or city prefilled with "Nottingham"
     When they add their residency date with a "recent" move year
     And they continue to confirm address
     Then they should see the confirm page
-    And they should see the address value "ZZZ MARINA"
-    And they should see the address value "ZZZ ROAD,"
-    And they should see the address value "LONG ZZZ NOTTINGHAM,"
+    And they should see the address value "Zzz Marina"
+    And they should see the address value "Zzz Road,"
+    And they should see the address value "Long Zzz Nottingham,"
     And they should see the address value "ZZ1 1ZZ"
 
 
   Scenario: organisation name and dependent street name of a business is not editable
     Then they should see the results page
-    And they have selected an address "ZZZ GROUP UNIT 2B ZZZ BUSINESS PARK 16 ZZZ PARK ZZZ STREET, SOME ZZZ LONG EATON GREAT MISSENDEN, ZZ1 1ZZ"
+    And they have selected an address "Zzz Group Unit 2b Zzz Business Park 16 Zzz Park Zzz Street, Some Zzz Long Eaton Great Missenden, ZZ1 1ZZ"
     Then they should see the address page
     And they should see the postcode prefilled with "ZZ1 1ZZ"
-    And they should see flat number prefilled with "UNIT 2B"
+    And they should see flat number prefilled with "Unit 2b"
     And they should see house number prefilled with "16"
-    And they should see house name prefilled with "ZZZ BUSINESS PARK"
-    And they should see street prefilled with "ZZZ STREET"
-    And they should see town or city prefilled with "GREAT MISSENDEN"
+    And they should see house name prefilled with "Zzz Business Park"
+    And they should see street prefilled with "Zzz Street"
+    And they should see town or city prefilled with "Great Missenden"
     When they add their residency date with a "recent" move year
     And they continue to confirm address
     Then they should see the confirm page
-    And they should see the address value "ZZZ GROUP UNIT 2B ZZZ BUSINESS PARK"
-    And they should see the address value "16 ZZZ PARK ZZZ STREET,"
-    And they should see the address value "SOME ZZZ LONG EATON GREAT MISSENDEN,"
+    And they should see the address value "Zzz Group Unit 2b Zzz Business Park"
+    And they should see the address value "16 Zzz Park Zzz Street,"
+    And they should see the address value "Some Zzz Long Eaton Great Missenden,"
     And they should see the address value "ZZ1 1ZZ"
 
   Scenario: no uprn is ok
     Then they should see the results page
-    And they have selected an address "R103 ZZZ PARK CREEK ROAD, ZZZ ISLAND, ZZ1 1ZZ"
+    And they have selected an address "R103 Zzz Park Creek Road, Zzz Island, ZZ1 1ZZ"
     Then they should see the address page
     And they should see the postcode prefilled with "ZZ1 1ZZ"
     And they should see flat number prefilled with ""
     And they should see house number prefilled with ""
     And they should see house name prefilled with "R103"
-    And they should see street prefilled with "CREEK ROAD"
-    And they should see town or city prefilled with "ZZZ ISLAND"
+    And they should see street prefilled with "Creek Road"
+    And they should see town or city prefilled with "Zzz Island"
     When they add their residency date with a "recent" move year
     And they continue to confirm address
     Then they should see the confirm page
     And they should see the address value "R103"
-    And they should see the address value "ZZZ PARK CREEK ROAD,"
-    And they should see the address value "ZZZ ISLAND,"
+    And they should see the address value "Zzz Park Creek Road,"
+    And they should see the address value "Zzz Island,"
     And they should see the address value "ZZ1 1ZZ"
 
   Scenario: dependent address locality is not editable
     Then they should see the results page
-    And they have selected an address "13 ZZZ CRESCENT, NEW PITSLIGO FRASERBURGH, ZZ1 1ZZ"
+    And they have selected an address "13 Zzz Crescent, New Pitsligo Fraserburgh, ZZ1 1ZZ"
     Then they should see the address page
     And they should see the postcode prefilled with "ZZ1 1ZZ"
     And they should see flat number prefilled with ""
     And they should see house number prefilled with "13"
     And they should see house name prefilled with ""
-    And they should see street prefilled with "ZZZ CRESCENT"
-    And they should see town or city prefilled with "FRASERBURGH"
+    And they should see street prefilled with "Zzz Crescent"
+    And they should see town or city prefilled with "Fraserburgh"
     When they add their residency date with a "recent" move year
     And they continue to confirm address
     Then they should see the confirm page
     And they should see the address value "13"
-    And they should see the address value "ZZZ CRESCENT,"
-    And they should see the address value "NEW PITSLIGO FRASERBURGH,"
+    And they should see the address value "Zzz Crescent,"
+    And they should see the address value "New Pitsligo Fraserburgh,"
     And they should see the address value "ZZ1 1ZZ"
 
   Scenario: organisation name and dependent street name is not editable
     Then they should see the results page
-    And they have selected an address "3 ZZZ WALK, MIDDLESBROUGH, ZZ1 1ZZ"
+    And they have selected an address "3 Zzz Walk, Middlesbrough, ZZ1 1ZZ"
     Then they should see the address page
     And they should see the postcode prefilled with "ZZ1 1ZZ"
     And they should see flat number prefilled with ""
     And they should see house number prefilled with "3"
     And they should see house name prefilled with ""
-    And they should see street prefilled with "ZZZ WALK"
-    And they should see town or city prefilled with "MIDDLESBROUGH"
+    And they should see street prefilled with "Zzz Walk"
+    And they should see town or city prefilled with "Middlesbrough"
     When they add their residency date with a "recent" move year
     And they continue to confirm address
     Then they should see the confirm page
     And they should see the address value "3"
-    And they should see the address value "ZZZ WALK,"
-    And they should see the address value "MIDDLESBROUGH,"
+    And they should see the address value "Zzz Walk,"
+    And they should see the address value "Middlesbrough,"
     And they should see the address value "ZZ1 1ZZ"

--- a/test/browser/features/address-search-previous.feature
+++ b/test/browser/features/address-search-previous.feature
@@ -6,7 +6,7 @@ Feature: Happy Path - previous
       Given Authenticalable Address Amy is using the system
       And they have started the address journey
       And they searched for their postcode "E1 8QS"
-      Then they have selected an address "10 WHITECHAPEL HIGH STREET, LONDON, E1 8QS"
+      Then they have selected an address "10 Whitechapel High Street, London, E1 8QS"
       When they add their residency date with a "recent" move year
       And they continue to confirm address
       And they select the previous UK address within three months radio button
@@ -15,7 +15,7 @@ Feature: Happy Path - previous
     Scenario: Previous address - Searching and successfully returning a postcode and saving a single address
       Given they searched for their postcode "E1 8QS"
       Then they should see the results page
-      And they have selected an address "1 WHITECHAPEL HIGH STREET, LONDON, E1 8QS"
+      And they have selected an address "1 Whitechapel High Street, London, E1 8QS"
       Then they should see the address page
 
     Scenario: Previous address - Searching and unsuccessfully finding an address and continuing

--- a/test/browser/pages/result.js
+++ b/test/browser/pages/result.js
@@ -12,7 +12,7 @@ module.exports = class PlaywrightDevPage {
     return this.paths.findIndex((path) => path === pathname) !== -1;
   }
 
-  async selectAddress(value = "10 WHITECHAPEL HIGH STREET, LONDON, E1 8QS") {
+  async selectAddress(value = "10 Whitechapel High Street, London, E1 8QS") {
     await this.page.click(".govuk-select");
     await this.page.selectOption(".govuk-select", {
       value,

--- a/test/data/testData.js
+++ b/test/data/testData.js
@@ -33,6 +33,38 @@ module.exports = {
       },
     ],
   },
+  titleCasedAddresses: [
+    {
+      buildingNumber: "1",
+      streetName: "Some Road",
+      addressLocality: "Somewhere",
+      postalCode: "SOMEPOST",
+    },
+    {
+      buildingName: "Named Building",
+      streetName: "Some Road",
+      addressLocality: "Somewhere",
+      postalCode: "SOMEPOST",
+    },
+    {
+      organisationName: "Named Org",
+      departmentName: "My Department",
+      buildingName: "Named Building",
+      streetName: "Some Road",
+      addressLocality: "Somewhere",
+      postalCode: "SOMEPOST",
+    },
+    {
+      subBuildingName: "Subbuilding Name",
+      buildingName: "Named Building",
+      dependentStreetName: "Some Dependent Road",
+      streetName: "Some Road",
+      doubleDependentAddressLocality: "Somewhere Double Dep",
+      dependentAddressLocality: "Somewhere Dep",
+      addressLocality: "Somewhere",
+      postalCode: "SOMEPOST",
+    },
+  ],
   formattedAddressed: [
     {
       buildingNumber: "1",


### PR DESCRIPTION
## Proposed changes

### What changed

Basic title case implementation on addressResults from a postcode search. Added titleCaseAddresses which any addressResults from a postcode search will be passed into.

Lots of browser tests updated due to address strings no longer being caps.

### Why did it change

To have consistent styling and addresses displayed in an easy-to-read format, so that I can clearly verify my information and have a better overall experience.

This is not a perfect solution, only a basic implementation. 

### Issue tracking

- [OJ-2913](https://govukverify.atlassian.net/browse/OJ-2913)

### Evidence

![image](https://github.com/user-attachments/assets/0007b57d-930b-4553-9ac1-59eff59b1e23)

[OJ-2913]: https://govukverify.atlassian.net/browse/OJ-2913?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ