### PR TITLE
Oj 2951 bug fixes

### DIFF
--- a/src/app/address/controllers/address/search.js
+++ b/src/app/address/controllers/address/search.js
@@ -67,7 +67,11 @@ class AddressSearchController extends BaseController {
     const titleCasedAddresses = addresses.map((address) => {
       const tempAddress = {};
       for (let key in address) {
-        if (typeof address[key] === "string" && key !== "postalCode") {
+        if (
+          typeof address[key] === "string" &&
+          key !== "postalCode" &&
+          key !== "addressCountry"
+        ) {
           tempAddress[key] = address[key].replace(
             /\w\S*/g,
             (text) =>

--- a/src/app/address/controllers/address/search.test.js
+++ b/src/app/address/controllers/address/search.test.js
@@ -148,6 +148,16 @@ describe("Address Search controller", function () {
       expect(returnedAddresses).to.deep.equal(addresses);
     });
 
+    it("should not title case country field", () => {
+      const addresses = [
+        {
+          addressCountry: "GB",
+        },
+      ];
+      const returnedAddresses = addressSearch.titleCaseAddresses(addresses);
+      expect(returnedAddresses).to.deep.equal(addresses);
+    });
+
     it("should return empty array if addresses is empty", () => {
       const returnedAddresses = addressSearch.titleCaseAddresses([]);
       expect(returnedAddresses).to.deep.equal([]);

--- a/src/locales/cy/default.yml
+++ b/src/locales/cy/default.yml
@@ -5,7 +5,7 @@ buttons:
   find-address: "Darganfyddwch gyfeiriad"
 buildingAddress:
   label: Building address
-  hint: Fill in at least 1 field in this section
+  hint: Rhowch o leiaf un
 govuk:
   serviceName: "Profi pwy ydych chi"
   backLink: "Yn ôl"

--- a/src/locales/cy/default.yml
+++ b/src/locales/cy/default.yml
@@ -4,7 +4,7 @@ buttons:
   cancel: "Canslo"
   find-address: "Darganfyddwch gyfeiriad"
 buildingAddress:
-  label: Building address
+  label: Cyfeiriad adeilad
   hint: Rhowch o leiaf un
 govuk:
   serviceName: "Profi pwy ydych chi"

--- a/src/locales/cy/pages.yml
+++ b/src/locales/cy/pages.yml
@@ -42,10 +42,11 @@ address-form:
   title: "Rhowch eich cyfeiriad"
   check-details:
     title: "Gwiriwch eich cyfeiriad"
-  previous:
-    title: "Rhowch eich cyfeiriad blaenorol"
-    check-details:
-      title: "Gwiriwch eich cyfeiriad blaenorol"
+
+address-form-previous:
+  title: "Rhowch eich cyfeiriad blaenorol"
+  check-details:
+    title: "Gwiriwch eich cyfeiriad blaenorol"
 
 enter-nonUK-address-form:
   title: Enter your address

--- a/src/locales/en/default.yml
+++ b/src/locales/en/default.yml
@@ -5,7 +5,7 @@ buttons:
   find-address: Find address
 buildingAddress:
   label: Building address
-  hint: Fill in at least 1 field in this section
+  hint: Fill in at least one
 govuk:
   serviceName: Prove your identity
   backLink: Back

--- a/src/locales/en/pages.yml
+++ b/src/locales/en/pages.yml
@@ -42,10 +42,11 @@ address-form:
   title: Enter your address
   check-details:
     title: Check your address
-  previous:
-    title: Enter your previous address
-    check-details:
-      title: Check your previous address
+
+address-form-previous:
+  title: Enter your previous address
+  check-details:
+    title: Check your previous address
 
 enter-nonUK-address-form:
   title: Enter your address

--- a/src/views/previous/address.njk
+++ b/src/views/previous/address.njk
@@ -10,9 +10,9 @@
 {% block mainContent %}
 
     {% if values.checkDetailsHeader === true %}
-      <h1 id="header" class="govuk-heading-l">{{translate("pages.address-form.previous.check-details.title")}}</h1>
+      <h1 id="header" class="govuk-heading-l">{{translate("pages.address-form-previous.check-details.title")}}</h1>
     {% else %}
-      <h1 id="header" class="govuk-heading-l">{{translate("pages.address-form.previous.title")}}</h1>
+      <h1 id="header" class="govuk-heading-l">{{translate("pages.address-form-previous.title")}}</h1>
     {% endif %}
 
   {{hmpoHtml(translate("links.previous.changePostcode"))}}


### PR DESCRIPTION
## Proposed changes

### What changed

Bug 1 - Change text for building address component hint from 'Fill in at least 1 field in this section' to 'Fill in at least one'
Fix 1 - Simple text change of 
```
buildingAddress:
  label: Building address
  hint: Fill in at least one
```

Bug - The tab on the previous address form was displaying as 'address-form-previous.title'. 
Fix 2 - Text fields were not being found, renamed/restructured them.

Bug 3 - The recent title case changed had broken the previous address comparison. The country code was also title cased and for UK address this is replaced with hardcoded in caps GB.
Fix 3 - Added addressCountry to exceptions for title casing


### Issue tracking

- [OJ-2951](https://govukverify.atlassian.net/browse/OJ-2951)



[OJ-2951]: https://govukverify.atlassian.net/browse/OJ-2951?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ