### PR TITLE
OJ-2951: Refactor addressFormTitle to move conditional out of template

### DIFF
--- a/src/app/address/controllers/address/manual.js
+++ b/src/app/address/controllers/address/manual.js
@@ -30,9 +30,7 @@ class AddressController extends BaseController {
         values.addressYearFrom = yearFrom;
       }
 
-      if (req.url.includes("edit")) {
-        values.checkDetailsHeader = "false";
-      }
+      values.addressFormTitle = this.getAddressFormTitle(req.originalUrl || "");
 
       if (req?.form?.errors) {
         const errorValues =
@@ -53,6 +51,7 @@ class AddressController extends BaseController {
             visuallyHiddenText: "error",
           };
       }
+
       callback(null, values);
     });
   }
@@ -141,6 +140,22 @@ class AddressController extends BaseController {
     });
 
     return hasChanged !== -1;
+  }
+
+  getAddressFormTitle(originalUrl) {
+    if (originalUrl.includes("previous") && originalUrl.includes("edit")) {
+      return "pages.address-form-previous.check-details.title";
+    }
+
+    if (originalUrl.includes("previous")) {
+      return "pages.address-form-previous.title";
+    }
+
+    if (originalUrl.includes("edit")) {
+      return "pages.address-form.check-details.title";
+    }
+
+    return "pages.address-form.title";
   }
 }
 module.exports = AddressController;

--- a/src/app/address/controllers/address/manual.test.js
+++ b/src/app/address/controllers/address/manual.test.js
@@ -42,6 +42,7 @@ describe("address controller", () => {
       expect(next).to.have.been.calledOnce;
       expect(next).to.have.been.calledWith(null, {
         addressPostcode: generatedAddress[0].postalCode,
+        addressFormTitle: "pages.address-form.title",
       });
     });
 
@@ -66,16 +67,6 @@ describe("address controller", () => {
       );
     });
 
-    it("should set checkDetailsHeader to false if the user is editing", () => {
-      req.url = "/address/edit";
-      address.getValues(req, res, next);
-
-      expect(next).to.have.been.calledWith(null, {
-        addressPostcode: undefined,
-        checkDetailsHeader: "false",
-      });
-    });
-
     it("sets field and group level errors", () => {
       req.translate = (args) => args;
       req.form.errors = {
@@ -97,6 +88,7 @@ describe("address controller", () => {
 
       expect(next).to.have.been.calledWith(null, {
         addressPostcode: undefined,
+        addressFormTitle: "pages.address-form.title",
         errors: {
           addressHouseName: {
             text: "addressHouseName.validation.alphaNumericWithSpecialChars",
@@ -124,12 +116,75 @@ describe("address controller", () => {
 
       expect(next).to.have.been.calledWith(null, {
         addressPostcode: undefined,
+        addressFormTitle: "pages.address-form.title",
         errors: {
           ukBuildingAddressEmptyValidator: {
             text: "validation.ukBuildingAddressEmptyValidator",
             visuallyHiddenText: "error",
           },
         },
+      });
+    });
+
+    context("viewing /address", () => {
+      it("should populate addressFormTitle with pages.address-form.title", () => {
+        address.getValues(req, res, next);
+
+        expect(next).to.have.been.calledOnce;
+        expect(next).to.have.been.calledWith(null, {
+          addressPostcode: undefined,
+          addressFormTitle: "pages.address-form.title",
+        });
+
+        req.originalUrl = "/address";
+        address.getValues(req, res, next);
+
+        expect(next).to.have.been.calledWith(null, {
+          addressPostcode: undefined,
+          addressFormTitle: "pages.address-form.title",
+        });
+      });
+    });
+
+    context("viewing /previous/address", () => {
+      it("should populate addressFormTitle with pages.address-form-previous.title", () => {
+        req.originalUrl = "/previous/address";
+
+        address.getValues(req, res, next);
+
+        expect(next).to.have.been.calledOnce;
+        expect(next).to.have.been.calledWith(null, {
+          addressPostcode: undefined,
+          addressFormTitle: "pages.address-form-previous.title",
+        });
+      });
+    });
+
+    context("viewing /address/edit?edit=true", () => {
+      it("should populate addressFormTitle with pages.address-form.check-details.title", () => {
+        req.originalUrl = "/address/edit?edit=true";
+
+        address.getValues(req, res, next);
+
+        expect(next).to.have.been.calledOnce;
+        expect(next).to.have.been.calledWith(null, {
+          addressPostcode: undefined,
+          addressFormTitle: "pages.address-form.check-details.title",
+        });
+      });
+    });
+
+    context("viewing /previous/address/edit?edit=true", () => {
+      it("should populate addressFormTitle with pages.address-form-previous.check-details.title", () => {
+        req.originalUrl = "/previous/address/edit?edit=true";
+
+        address.getValues(req, res, next);
+
+        expect(next).to.have.been.calledOnce;
+        expect(next).to.have.been.calledWith(null, {
+          addressPostcode: undefined,
+          addressFormTitle: "pages.address-form-previous.check-details.title",
+        });
       });
     });
   });

--- a/src/views/address/address.njk
+++ b/src/views/address/address.njk
@@ -14,11 +14,7 @@
 
 {% block mainContent %}
 
-   {% if values.checkDetailsHeader === true %}
-   <h1 id="header" class="govuk-heading-l">{{translate("pages.address-form.check-details.title")}}</h1>
-  {% else %}
-    <h1 id="header" class="govuk-heading-l">{{translate("pages.address-form.title")}}</h1>
-  {% endif %}
+  <h1 id="header" class="govuk-heading-l">{{translate(values.addressFormTitle)}}</h1>
 
   {{hmpoHtml(translate("links.changePostcode"))}}
 

--- a/src/views/previous/address.njk
+++ b/src/views/previous/address.njk
@@ -9,11 +9,7 @@
 
 {% block mainContent %}
 
-    {% if values.checkDetailsHeader === true %}
-      <h1 id="header" class="govuk-heading-l">{{translate("pages.address-form-previous.check-details.title")}}</h1>
-    {% else %}
-      <h1 id="header" class="govuk-heading-l">{{translate("pages.address-form-previous.title")}}</h1>
-    {% endif %}
+  <h1 id="header" class="govuk-heading-l">{{translate(values.addressFormTitle)}}</h1>
 
   {{hmpoHtml(translate("links.previous.changePostcode"))}}
 


### PR DESCRIPTION
## Proposed changes

### What changed

Refactored addressFormTitle logic to be in the controller rather than a conditional in the nunjucks file. 

### Why did it change

![image](https://github.com/user-attachments/assets/efa9f1ff-dd06-437b-a2ca-5fd9e2bcb4eb)

### Issue tracking

- [OJ-2951](https://govukverify.atlassian.net/browse/OJ-2951)


[OJ-2951]: https://govukverify.atlassian.net/browse/OJ-2951?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ