### PR TITLE
OJ-2883: Add welsh translations

### DIFF
--- a/src/app/address/controllers/address/nonUKAddress.js
+++ b/src/app/address/controllers/address/nonUKAddress.js
@@ -27,7 +27,7 @@ class NonUKAddressController extends BaseController {
       values.buildingAddressEmptyErrorMessage = this.isBuildingAddressEmpty(
         req
       ) && {
-        text: req.translate("validation.apartmentOrBuildingNumberOrName"),
+        text: req.translate("validation.buildingAddressEmptyValidator"),
         visuallyHiddenText: "error",
       };
 
@@ -48,7 +48,7 @@ class NonUKAddressController extends BaseController {
     ];
 
     buildingAddress.every(fieldIsEmpty) &&
-      this.defaultToFirstField(formFields, apartment, req);
+      this.defaultToFirstField(formFields, apartment);
 
     super.validateFields(req, res, callback);
   }
@@ -89,10 +89,9 @@ class NonUKAddressController extends BaseController {
     };
   }
 
-  defaultToFirstField(formFields, first, req) {
+  defaultToFirstField(formFields, first) {
     formFields[first].validate.push({
       fn: buildingAddressEmptyValidator,
-      message: req.translate("validation.apartmentOrBuildingNumberOrName"),
     });
   }
 

--- a/src/app/address/controllers/address/nonUKAddress.test.js
+++ b/src/app/address/controllers/address/nonUKAddress.test.js
@@ -107,8 +107,7 @@ describe("NonUKAddressController", () => {
 
       expect(address.defaultToFirstField).to.have.been.calledOnceWith(
         req.form.options.fields,
-        "nonUKAddressApartmentNumber",
-        req
+        "nonUKAddressApartmentNumber"
       );
       expect(next).to.have.been.calledOnce;
     });
@@ -130,8 +129,7 @@ describe("NonUKAddressController", () => {
 
       expect(address.defaultToFirstField).not.to.have.been.calledOnceWith(
         req.form.options.fields,
-        "nonUKAddressApartmentNumber",
-        req
+        "nonUKAddressApartmentNumber"
       );
       expect(next).to.have.been.calledOnce;
     });

--- a/src/locales/cy/default.yml
+++ b/src/locales/cy/default.yml
@@ -98,7 +98,7 @@ validation:
   alphaNumericWithSpecialChars: "Ni ddylai eich {{ label }} gynnwys unrhyw nodau neu symbolau arbennig"
   default: "Mae'n rhaid i chi ateb y cwestiwn hwn"
   houseNameOrHouseNumber: "Rhowch enw tŷ neu rif tŷ"
-  apartmentOrBuildingNumberOrName: Rhowch rif fflat, rhif adeilad neu enw adeilad
+  buildingAddressEmptyValidator: Rhowch rif fflat, rhif adeilad neu enw adeilad
 
 addressSelect:
   addressFoundWithCount_one: "Darganfyddwyd {{ count }} cyfeiriad"

--- a/src/locales/cy/default.yml
+++ b/src/locales/cy/default.yml
@@ -76,8 +76,8 @@ links:
   changeYearFrom: '<a href="/address/edit?edit=true" id="change-address" data-id="changeAddress" class="govuk-link">Newid<span class="govuk-visually-hidden"> y flwyddyn y dechreuoch chi fyw yn eich cyfeiriad presennol</span></a>'
   changePostcode: '<p>Cod post <br> <span data-id="changePostcodeValue"><b>{{values.addressPostcode}}</b></span> &nbsp;&nbsp;&nbsp;&nbsp; <a href="/search" data-id="changePostcode" class="govuk-link">Newid<span class="govuk-visually-hidden"> eich cod post presennol</span></a></p>'
   changeCountry:
-    label: Country
-    title: your current country
+    label: "Gwlad"
+    title: "eich gwlad presennol"
   cantFindAddress:
     - '<p><a href="/address" data-id="cantFindAddress" class="govuk-link">Ni allaf ddod o hyd i fy nghyfeiriad ar y rhestr</a></p>'
   previous:

--- a/src/locales/cy/fields.yml
+++ b/src/locales/cy/fields.yml
@@ -33,47 +33,44 @@ addressLocality:
     maxlength: "Gwiriwch eich bod wedi rhoi enw eich tref neu ddinas yn yn gywir"
 
 nonUKAddressApartmentNumber:
-  label: Apartment number
+  label: "Rhif fflat"
   validation:
-    maxlength: Check you've entered your apartment number correctly
-    alphaNumericWithSpecialChars: Apartment number must only include numbers 0 to 9, letters a to z and .,-\/* or '
+    alphaNumericWithSpecialChars: "Rhaid i rif y fflat ond cynnwys rhifau 0 i 9, llythrennau a i z a .,-\/* neu '"
 
 nonUKAddressBuildingNumber:
-  label: Building number
+  label: "Rhif adeilad"
   validation:
-    maxlength: Check you've entered your building number correctly
-    alphaNumericWithSpecialChars: Building number must only include numbers 0 to 9, letters a to z and .,-\/* or '
+    alphaNumericWithSpecialChars: "Rhaid i rif yr adeilad ond cynnwys rhifau 0 i 9, llythrennau a i z a .,-\/* neu '"
 
 nonUKAddressBuildingName:
-  label: Building name
+  label: "Enw adeilad"
   validation:
-    maxlength: Check you've entered your building name correctly
-    alphaNumericWithSpecialChars: Building name must only include letters a to z, numbers 0 to 9 and .,-\/* or '
+    alphaNumericWithSpecialChars: "Rhaid i enw'r adeilad ond cynnwys rhifau 0 i 9, llythrennau a i z a .,-\/* neu '"
 
 nonUKAddressStreetName:
-  label: Street name (optional)
+  label: "Enw stryd (dewisol)"
   validation:
-    maxlength: Check you've entered your street name correctly
-    alphaNumericWithSpecialChars: Street name must only include letters a to z, numbers 0 to 9 and .,-\/* or '
+    maxlength: "Gwiriwch eich bod wedi rhoi enw eich stryd yn gywir"
+    alphaNumericWithSpecialChars: "Rhaid i enw'r stryd ond cynnwys rhifau 0 i 9, llythrennau a i z a .,-\/* neu '"
 
 nonUKAddressLocality:
-  label: Town, suburb or city
+  label: "Tref, maestref neu ddinas"
   validation:
-    maxlength: Check you've entered your town, suburb or city correctly
-    alphaNumericWithSpecialChars: Town, suburb or city must only include letters a to z, numbers 0 to 9 and .,-\/* or '
+    maxlength: "Gwiriwch eich bod wedi rhoi enw eich tref, maestref neu ddinas yn gywir"
+    alphaNumericWithSpecialChars: "Rhaid i enw'r tref, maestref neu ddinas ond cynnwys rhifau 0 i 9, llythrennau a i z a .,-\/* neu '"
 
 nonUKAddressPostalCode:
-  label: Postal code or zipcode (if your country has one)
+  label: "Cod post neu god zip (os oes gan eich gwlad un)"
   validation:
-    maxlength: Check you've entered your postal code or zipcode correctly
-    alphaNumericWithSpecialChars: Postal code or zipcode must only include numbers 0 to 9, letters a to z and .,-\/* or '
+    maxlength: "Gwiriwch eich bod wedi rhoi eich cod post neu god zip yn gywir"
+    alphaNumericWithSpecialChars: "Rhaid i god post neu god zip ond cynnwys rhifau 0 i 9, llythrennau a i z a .,-\/* neu '"
 
 nonUKAddressRegion:
-  label: Region (optional)
-  hint: For example, state, district, county, parish or province
+  label: "Rhanbarth (dewisol)"
+  hint: "Er enghraifft, gwlad, ardal, sir, plwyf neu dalaith"
   validation:
-    maxlength: Check you've entered your region correctly
-    alphaNumericWithSpecialChars: Region must only include letters a to z, numbers 0 to 9 and .,-\/* or '
+    maxlength: "Gwiriwch eich bod wedi rhoi eich rhanbarth yn gywir"
+    alphaNumericWithSpecialChars: "Rhaid i rhanbarth ond cynnwys rhifau 0 i 9, llythrennau a i z a .,-\/* neu '"
 
 nonUKAddressYearFrom:
   title: "Pryd wnaethoch chi ddechrau byw yno?"
@@ -139,7 +136,7 @@ hasPreviousUKAddressWithinThreeMonths:
 country:
   placeholder: ""
   validation:
-    required: Select the country you live in
+    required: Dewiswch y wlad rydych yn byw ynddi
 
 countries:
   AF: Afghanistan

--- a/src/locales/cy/pages.yml
+++ b/src/locales/cy/pages.yml
@@ -14,7 +14,7 @@ done:
   title: "Wedi'i wneud"
 
 country:
-  title: What country do you live in?
+  title: "Ym mha wlad ydych chi'n byw?"
 
 addressSearch:
   title: "Darganfyddwch eich cyfeiriad"
@@ -49,7 +49,7 @@ address-form-previous:
     title: "Gwiriwch eich cyfeiriad blaenorol"
 
 enter-nonUK-address-form:
-  title: Enter your address
+  title: "Rhowch eich cyfeiriad"
 
 addressProblem:
   title: "Mae’n ddrwg gennym, mae problem"

--- a/src/locales/en/default.yml
+++ b/src/locales/en/default.yml
@@ -100,7 +100,7 @@ validation:
   alphaNumericWithSpecialChars: Your {{ label }} should not include any special characters or symbols
   default: You must answer this question
   houseNameOrHouseNumber: Enter a house name or house number
-  apartmentOrBuildingNumberOrName: Enter an apartment number, building number or building name
+  buildingAddressEmptyValidator: Enter an apartment number, building number or building name
 addressSelect:
   addressFoundWithCount_one: "{{ count }} address found"
   addressFoundWithCount_other: "{{ count }} addresses found"

--- a/src/locales/en/fields.yml
+++ b/src/locales/en/fields.yml
@@ -41,19 +41,16 @@ addressLocality:
 nonUKAddressApartmentNumber:
   label: Apartment number
   validation:
-    maxlength: Check you've entered your apartment number correctly
     alphaNumericWithSpecialChars: Apartment number must only include numbers 0 to 9, letters a to z and .,-\/* or '
 
 nonUKAddressBuildingNumber:
   label: Building number
   validation:
-    maxlength: Check you've entered your building number correctly
     alphaNumericWithSpecialChars: Building number must only include numbers 0 to 9, letters a to z and .,-\/* or '
 
 nonUKAddressBuildingName:
   label: Building name
   validation:
-    maxlength: Check you've entered your building name correctly
     alphaNumericWithSpecialChars: Building name must only include letters a to z, numbers 0 to 9 and .,-\/* or '
 
 nonUKAddressStreetName:


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

- Add welsh translations
- Removed `maxlength` where we haven't implemented `maxlength` validation
- Stopped creating our own `message` for the `buildingAddressEmptyValidator` error because the translation doesn't get updated when the language is changed

### Screenshots

![Screenshot 2024-12-12 at 2 38 34 PM](https://github.com/user-attachments/assets/a4dde89f-949f-4489-a552-5d8e5a7a4f0d)
![Screenshot 2024-12-12 at 2 40 34 PM](https://github.com/user-attachments/assets/ca7da08c-7fda-402d-8929-e06d673e3aa3)
![Screenshot 2024-12-12 at 2 41 06 PM](https://github.com/user-attachments/assets/474016c5-ae00-4652-abfb-43da765566b5)
![Screenshot 2024-12-12 at 2 43 01 PM](https://github.com/user-attachments/assets/ac96c56a-0596-427d-851c-aab299833d06)
![Screenshot 2024-12-12 at 2 44 23 PM](https://github.com/user-attachments/assets/6fcbe395-3b67-45d6-8fee-f909637cbfa2)
![Screenshot 2024-12-12 at 2 44 35 PM](https://github.com/user-attachments/assets/d90af417-f118-406e-9dcb-d55f5cc1a5fc)


### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [OJ-2883](https://govukverify.atlassian.net/browse/OJ-2883)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [x] No environment variables or secrets were added or changed

[OJ-2883]: https://govukverify.atlassian.net/browse/OJ-2883?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ