### PR TITLE
OJ-2864: Add overload-protection

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "check-translation": "node node_modules/@govuk-one-login/di-ipv-cri-common-express/scripts/checkTranslations.js '../../../../src/locales'"
   },
   "dependencies": {
+    "overload-protection": "1.2.3",
     "@aws-sdk/client-dynamodb": "3.609.0",
     "@govuk-one-login/di-ipv-cri-common-express": "8.1.0",
     "@govuk-one-login/frontend-analytics": "3.0.1",
@@ -55,6 +56,7 @@
     "wiremock": "3.8.0"
   },
   "devDependencies": {
+    "@types/overload-protection": "1.2.4",
     "@cucumber/cucumber": "11.0.1",
     "chai": "4.4.1",
     "chai-as-promised": "7.1.1",

--- a/src/app.js
+++ b/src/app.js
@@ -41,6 +41,8 @@ const loggerConfig = {
   app: false,
 };
 
+const protect = require("overload-protection");
+
 const dynamodb = new DynamoDB({
   region: "eu-west-2",
 });
@@ -110,6 +112,19 @@ const { app, router } = setup({
       ],
     });
     app.use(setHeaders);
+
+    app.use(
+      protect("express", {
+        production: process.env.NODE_ENV === "production",
+        clientRetrySecs: 1,
+        sampleInterval: 5,
+        maxEventLoopDelay: 52,
+        maxHeapUsedBytes: 0,
+        maxRssBytes: 0,
+        errorPropagationMode: false,
+        logging: "error",
+      })
+    );
   },
   dev: true,
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1941,6 +1941,11 @@
   resolved "https://registry.yarnpkg.com/@types/normalize-package-data/-/normalize-package-data-2.4.4.tgz#56e2cc26c397c038fab0e3a917a12d5c5909e901"
   integrity sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==
 
+"@types/overload-protection@1.2.4":
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/@types/overload-protection/-/overload-protection-1.2.4.tgz#d0ebacee6c95be3421ab252edbc2b801a74ee9b5"
+  integrity sha512-zbKBN5pZXwF4yiXUeF0Cng4Y+sqqTWVeyi++uR6Ycd8oThOGPBMEdHyX81Z1vU4wojh9+NDS0y6JX7nM6ylBCw==
+
 "@types/responselike@^1.0.0":
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/@types/responselike/-/responselike-1.0.3.tgz#cc29706f0a397cfe6df89debfe4bf5cea159db50"
@@ -4591,6 +4596,13 @@ lolex@^5.0.1:
   dependencies:
     "@sinonjs/commons" "^1.7.0"
 
+loopbench@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/loopbench/-/loopbench-1.2.0.tgz#7601b73f57097c73f426a05ebf781ab7ea4917ff"
+  integrity sha512-ft2PmuZnDw+DJQfT5mpEWudEBRzlpImh7mU7OcPGmefsKlW8Ck0U6nrCCdcwYF+z9zc0SVBzGZA1F1gUfHZuJw==
+  dependencies:
+    xtend "^4.0.1"
+
 loupe@^2.3.6:
   version "2.3.7"
   resolved "https://registry.yarnpkg.com/loupe/-/loupe-2.3.7.tgz#6e69b7d4db7d3ab436328013d37d1c8c3540c697"
@@ -5110,6 +5122,13 @@ optionator@^0.9.3:
     prelude-ls "^1.2.1"
     type-check "^0.4.0"
     word-wrap "^1.2.5"
+
+overload-protection@1.2.3:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/overload-protection/-/overload-protection-1.2.3.tgz#a0e75845a1ccbc9ec9c6039936454ba35500b1ad"
+  integrity sha512-b7XZbmhujnqNoK0Z6NPzA/nhfQnE08ZTHSzzjTMwegb5N9oBAAApx3f9u2R/f3VGaACTQj6QJnGUfX1oFttqfg==
+  dependencies:
+    loopbench "^1.2.0"
 
 p-cancelable@^2.0.0:
   version "2.1.1"
@@ -6684,7 +6703,7 @@ xmlbuilder@^15.1.1:
   resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-15.1.1.tgz#9dcdce49eea66d8d10b42cae94a79c3c8d0c2ec5"
   integrity sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==
 
-xtend@~4.0.1:
+xtend@^4.0.1, xtend@~4.0.1:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.2.tgz#bb72779f5fa465186b1f438f674fa347fdb5db54"
   integrity sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==


### PR DESCRIPTION
## Proposed changes

### What changed
Added overload-protection library to app.js

### Why did it change
To prevent node from accepting too many connections and putting itself into a blocking state.

### Issue tracking
- [OJ-2864](https://govukverify.atlassian.net/browse/OJ-2864)

[OJ-2864]: https://govukverify.atlassian.net/browse/OJ-2864?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ