### PR TITLE
OJ-2965: Add responseLatency to API GW log settings

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -618,7 +618,8 @@ Resources:
           "routeKey":"$context.routeKey",
           "status":"$context.status",
           "protocol":"$context.protocol",
-          "responseLength":"$context.responseLength"
+          "responseLength":"$context.responseLength",
+          "responseLatency":"$context.responseLatency"
           }
 
   APIGWAccessLogsGroup:


### PR DESCRIPTION
## Proposed changes

### What changed

Add responseLatency to API GW log settings

### Why did it change

To see exact frontend latency

### Screenshots

![image](https://github.com/user-attachments/assets/0aa69a5c-4a3d-4b24-a3a8-27b5dfc4228a)


### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [OJ-2965](https://govukverify.atlassian.net/browse/OJ-2965)

[OJ-2965]: https://govukverify.atlassian.net/browse/OJ-2965?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ