### PR TITLE
OJ-2959: tweaks to /what-country page

### DIFF
--- a/src/app/address/controllers/address/whatCountry.js
+++ b/src/app/address/controllers/address/whatCountry.js
@@ -1,0 +1,12 @@
+const BaseController = require("hmpo-form-wizard").Controller;
+
+class WhatCountryController extends BaseController {
+  async getValues(req, res, callback) {
+    super.getValues(req, res, (err, values) => {
+      values.country = "";
+      callback(err, values);
+    });
+  }
+}
+
+module.exports = WhatCountryController;

--- a/src/app/address/controllers/address/whatCountry.test.js
+++ b/src/app/address/controllers/address/whatCountry.test.js
@@ -1,0 +1,33 @@
+const { expect } = require("chai");
+const BaseController = require("hmpo-form-wizard").Controller;
+const WhatCountryController = require("./whatCountry");
+
+const address = new WhatCountryController({ route: "/test" });
+
+describe("whatCountryController", () => {
+  let req, res, sandbox;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+
+    sandbox
+      .stub(BaseController.prototype, "getValues")
+      .callsFake((_, __, callback) => callback(null, {}));
+    req = {
+      sessionModel: {
+        get: sandbox.stub(),
+        set: sandbox.stub(),
+      },
+    };
+  });
+
+  afterEach(() => sandbox.restore());
+
+  it("should set country to empty string", (done) => {
+    req.sessionModel.set("country", "test");
+    address.getValues(req, res, (err, values) => {
+      expect(values.country).to.be.eq("");
+      done();
+    });
+  });
+});

--- a/src/app/address/routes/address/steps.js
+++ b/src/app/address/routes/address/steps.js
@@ -3,6 +3,7 @@ const prepopulate = require("../../controllers/address/prepopulate");
 const search = require("../../controllers/address/search");
 const results = require("../../controllers/address/results");
 const nonUKAddressController = require("../../controllers/address/nonUKAddress");
+const whatCountryController = require("../../controllers/address/whatCountry");
 
 module.exports = {
   "/": {
@@ -24,6 +25,7 @@ module.exports = {
     ],
   },
   "/what-country": {
+    controller: whatCountryController,
     fields: ["country"],
     next: [
       ...["GB", "GG", "JE", "IM"].map((countryCode) => ({

--- a/src/assets/scss/components/_country-picker.scss
+++ b/src/assets/scss/components/_country-picker.scss
@@ -6,3 +6,7 @@
   z-index: 0;
   top: 8px;
 }
+
+.autocomplete__option {
+  margin-bottom: 0;
+}

--- a/test/browser/features/international-address-enter-address.feature
+++ b/test/browser/features/international-address-enter-address.feature
@@ -152,6 +152,7 @@ Feature: International address - Enter your address
     And they see the change country link "Kenya"
     When they click change country link
     Then they should see the country selector page
+    Then they have selected the country "Kenya"
     When they click the continue button
     Then they should see international address form
 
@@ -162,7 +163,7 @@ Feature: International address - Enter your address
     And they see the change country link "Kenya"
     When they click change country link
     Then they should see the country selector page
-    And they should also see the selected country is still "Kenya"
+    And they should also see the selected country is empty
     When they have selected the country "France"
     And they click the continue button
     Then they should see international address form
@@ -175,7 +176,7 @@ Feature: International address - Enter your address
     And they see the change country link "Kenya"
     When they click change country link
     Then they should see the country selector page
-    And they should also see the selected country is still "Kenya"
+    And they should also see the selected country is empty
     When they have selected the country "Isle of Man"
     And they click the continue button
     Then they should see the UK address form

--- a/test/browser/step_definitions/international.js
+++ b/test/browser/step_definitions/international.js
@@ -150,6 +150,14 @@ Then(
   }
 );
 
+Then("they should also see the selected country is empty", async function () {
+  const countryPage = new CountryPage(this.page);
+
+  const selectedCountry = await countryPage.getSelectedCountry();
+
+  expect(selectedCountry).to.equal("");
+});
+
 Then(
   "they see an error summary with failed validation message: {string}",
   async function (message) {


### PR DESCRIPTION
## Proposed changes

### What changed 

1. The margin-bottom has been removed from the country picker:

Before: 
![image](https://github.com/user-attachments/assets/5c10e269-448f-47b3-bf07-88d0edfe700c)

After:
<img width="664" alt="Screenshot 2025-01-06 at 12 36 43" src="https://github.com/user-attachments/assets/9c6815c0-5da4-4e2e-877e-1c72ef5a4bee" />

2. When the user presses the back button, the country picker no longer keeps the previous country pre-populated in the picker. 
<img width="717" alt="Screenshot 2025-01-06 at 12 37 30" src="https://github.com/user-attachments/assets/f4df6302-c79c-4157-9e27-c29c33294208" />

### Issue tracking
- [OJ-2959](https://govukverify.atlassian.net/browse/OJ-2959)

[OJ-2959]: https://govukverify.atlassian.net/browse/OJ-2959?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ