### PR TITLE
OJ-2992: Increased maxEventLoopDelay

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -118,7 +118,7 @@ const { app, router } = setup({
         production: process.env.NODE_ENV === "production",
         clientRetrySecs: 1,
         sampleInterval: 5,
-        maxEventLoopDelay: 80,
+        maxEventLoopDelay: 400,
         maxHeapUsedBytes: 0,
         maxRssBytes: 0,
         errorPropagationMode: false,


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Increased maxEventLoopDelay

### Why did it change

It looks like the threshold has been set too low which is causing the 503s. Core have seen spikes that aren’t being logged by the vital signs package so where they have the same average event loop delay as us they have set the max to 400 and are not seeing any issues. 

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [OJ-2992](https://govukverify.atlassian.net/browse/OJ-2992)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [x] No environment variables or secrets were added or changed



[OJ-2992]: https://govukverify.atlassian.net/browse/OJ-2992?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ