### PR TITLE
Updating pre-commit hooks to latest versions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v5.0.0
     hooks:
       - id: check-added-large-files
         exclude: package-lock.json
@@ -12,12 +12,12 @@ repos:
       - id: trailing-whitespace
         exclude: .yarn
   - repo: https://github.com/Yelp/detect-secrets
-    rev: v1.4.0
+    rev: v1.5.0
     hooks:
       - id: detect-secrets
         args: ["--baseline", ".secrets.baseline"]
   - repo: https://github.com/pre-commit/mirrors-eslint
-    rev: v8.55.0
+    rev: v9.16.0
     hooks:
       - id: eslint
         files: \.[jt]sx?$ # *.js, *.jsx, *.ts and *.tsx
@@ -28,7 +28,7 @@ repos:
     hooks:
       - id: prettier
   - repo: https://github.com/aws-cloudformation/cfn-lint
-    rev: v0.83.3
+    rev: v1.22.0
     hooks:
       - id: cfn-lint
         files: .template\.ya?ml$

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,0 +1,71 @@
+import globals from "globals";
+import mocha from "eslint-plugin-mocha";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import js from "@eslint/js";
+import { FlatCompat } from "@eslint/eslintrc";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const compat = new FlatCompat({
+  baseDirectory: __dirname,
+  recommendedConfig: js.configs.recommended,
+  allConfig: js.configs.all,
+});
+
+export default [
+  {
+    ignores: [
+      "**/wallaby.conf.js",
+      "**/node_modules",
+      "**/reports",
+      "**/.aws-sam",
+      "**/dist",
+    ],
+  },
+  ...compat.extends(
+    "prettier",
+    "eslint:recommended",
+    "plugin:prettier/recommended"
+  ),
+  {
+    languageOptions: {
+      globals: {
+        ...globals.node,
+        ...globals.mocha,
+        sinon: true,
+        expect: true,
+        setupDefaultMocks: true,
+      },
+    },
+
+    rules: {
+      "no-console": 2,
+
+      "padding-line-between-statements": [
+        "error",
+        {
+          blankLine: "any",
+          prev: "*",
+          next: "*",
+        },
+      ],
+    },
+  },
+  ...compat.extends("plugin:mocha/recommended").map((config) => ({
+    ...config,
+    files: ["src/**/*.test.js"],
+  })),
+  {
+    files: ["src/**/*.test.js"],
+
+    plugins: {
+      mocha,
+    },
+
+    rules: {
+      "mocha/no-mocha-arrows": 0,
+      "mocha/no-setup-in-describe": 0,
+    },
+  },
+];


### PR DESCRIPTION
Generated new eslint config using this tool:
https://eslint.org/docs/latest/use/configure/migration-guide

## Proposed changes
This bumps a few different pre-commit hooks, the one I need bumping is CFN Lint as the version we have is too old to know about predicitive scaling, so it's failing the check

### What changed
Bumped various pre-commit hooks - the one of not is eslint - version 9 has a new config format which I've migrated the current config over to - I'm not eslint savvy enough to check it properly though. 

### Why did it change
To be up to date.
