### PR TITLE
OJ-2960: Minor UCD address form changes

### DIFF
--- a/src/locales/cy/fields.yml
+++ b/src/locales/cy/fields.yml
@@ -78,9 +78,10 @@ nonUKAddressRegion:
 
 nonUKAddressYearFrom:
   title: "Pryd wnaethoch chi ddechrau byw yno?"
-  label: "Rhowch y flwyddyn y dechreuoch chi fyw yn y cyfeiriad hwn, er enghraifft 2017"
+  label: "Rhowch y flwyddyn y wnaethoch ddechrau byw yma, er enghraifft 2017"
   validation:
     default: "Rhowch y flwyddyn gan ddefnyddio 4 digid yn unig"
+    required: "Rhowch y flwyddyn"
     isPreviousDate: "Rhaid i'r dyddiad y dechreuoch chi fyw yn y cyfeiriad hwn fod yn y gorffennol"
 
 addressYearFrom:
@@ -88,6 +89,7 @@ addressYearFrom:
   label: "Rhowch y flwyddyn y wnaethoch ddechrau byw yma, er enghraifft 2017"
   validation:
     default: "Rhowch y flwyddyn gan ddefnyddio 4 digid yn unig"
+    required: "Rhowch y flwyddyn"
     isPreviousDate: "Rhaid i'r dyddiad y dechreuoch chi fyw yn y cyfeiriad hwn fod yn y gorffennol"
 addressResults:
   label: "Dewiswch eich cyfeiriad cartref presennol o'r rhestr"

--- a/src/locales/en/fields.yml
+++ b/src/locales/en/fields.yml
@@ -87,13 +87,15 @@ addressYearFrom:
   label: Enter the year you started living here, for example 2017
   validation:
     default: Enter the year using only 4 digits
+    required: Enter the year
     isPreviousDate: The date you started living at this address must be in the past
 
 nonUKAddressYearFrom:
   title: When did you start living at this address?
-  label: Enter the year you started living at this address, for example 2017
+  label: Enter the year you started living here, for example 2017
   validation:
     default: Enter the year using only 4 digits
+    required: Enter the year
     isPreviousDate: Enter a year that is not in the future
 
 addressResults:

--- a/test/browser/features/address-manual-preselected.feature
+++ b/test/browser/features/address-manual-preselected.feature
@@ -24,6 +24,12 @@ Feature: Happy Path - confirming preselected address details and date invalidati
       Given they are on the address page
       When they add their residency date with a "" move year
       And they continue to confirm address
+      Then they should see an error message on the address page "Enter the year"
+
+    Scenario: Changing address values and unsuccessfully passing validation when no date is invalid
+      Given they are on the address page
+      When they add their residency date with a "0" move year
+      And they continue to confirm address
       Then they should see an error message on the address page "Enter the year using only 4 digits"
 
     Scenario: Changing address values and unsuccessfully passing validation when the date is in the future

--- a/test/browser/features/international-address-enter-address.feature
+++ b/test/browser/features/international-address-enter-address.feature
@@ -85,7 +85,7 @@ Feature: International address - Enter your address
     And they add their Postal code or zipcode "00100"
     And they add their Region "Nairobi County"
     And they continue to confirm international address
-    Then they see an error summary with failed validation message: "Enter the year using only 4 digits"
+    Then they see an error summary with failed validation message: "Enter the year"
 
   Scenario: Enter international address details and fail validation due to future residential year
     Given they have selected the country "Kenya"
@@ -101,6 +101,21 @@ Feature: International address - Enter your address
     And they add the "future" year they started living at this address
     And they continue to confirm international address
     Then they see an error summary with failed validation message: "Enter a year that is not in the future"
+
+  Scenario: Enter international address details and fail validation due to invalid residential year
+    Given they have selected the country "Kenya"
+    When they click the continue button
+    Then they should see international address form
+    When they add their building address apartment number "A2"
+    And they add their building address name "Kilimanjaro Apartments"
+    And they add their building address number "45"
+    And they add their international street "Ngong Road"
+    And they add their town, suburb or city "Nairobi"
+    And they add their Postal code or zipcode "00100"
+    And they add their Region "Nairobi County"
+    And they add the "0" year they started living at this address
+    And they continue to confirm international address
+    Then they see an error summary with failed validation message: "Enter the year using only 4 digits"
 
   Scenario: Enter international address details and fail validation due to no building address information
     Given they have selected the country "Kenya"
@@ -119,7 +134,7 @@ Feature: International address - Enter your address
     When they click the continue button
     Then they should see international address form
     And they continue to confirm international address
-    Then they see an error summary with failed validation message: "Enter the year using only 4 digits"
+    Then they see an error summary with failed validation message: "Enter the year"
     Then they see an error summary with failed validation message: "Enter your town, suburb or city"
     Then they see an error summary with failed validation message: "Enter an apartment number, building number or building name"
     Then they see 3 building address input fields highlighted as invalid with error summary and message: "Enter an apartment number, building number or building name"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3221,7 +3221,7 @@ express-session@1.18.1, express-session@^1.17.3:
     safe-buffer "5.2.1"
     uid-safe "~2.1.5"
 
-express@4.21.2, express@^4.17.1:
+express@4.21.2:
   version "4.21.2"
   resolved "https://registry.yarnpkg.com/express/-/express-4.21.2.tgz#cf250e48362174ead6cea4a566abef0162c1ec32"
   integrity sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==
@@ -6070,16 +6070,7 @@ string-argv@^0.3.1:
   resolved "https://registry.yarnpkg.com/string-argv/-/string-argv-0.3.2.tgz#2b6d0ef24b656274d957d54e0a4bbf6153dc02b6"
   integrity sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.2, string-width@^5.0.0, string-width@^5.1.2:
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.2, string-width@^5.0.0, string-width@^5.1.2:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -6145,14 +6136,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
-
-strip-ansi@6.0.1, strip-ansi@^6.0.0, strip-ansi@^6.0.1, strip-ansi@^7.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@6.0.1, strip-ansi@^6.0.0, strip-ansi@^6.0.1, strip-ansi@^7.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -6600,16 +6584,7 @@ workerpool@^6.5.1:
   resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-6.5.1.tgz#060f73b39d0caf97c6db64da004cd01b4c099544"
   integrity sha512-Fs4dNYcsdpYSAfVxhnl1L5zTksjvOJxtC5hzMNl+1t9B8hTJTdKDyZ5ju7ztgPy+ft9tBFXoOlDNiOT9WUXZlA==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^6.2.0, wrap-ansi@^7.0.0, wrap-ansi@^8.1.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^6.2.0, wrap-ansi@^7.0.0, wrap-ansi@^8.1.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==


### PR DESCRIPTION
## Proposed changes

### What changed

- Change non UK address form year input hint from 'Enter the year you started living at this address, for example 2017' to 'Enter the year you started living here, for example 2017' 
- Change year input field empty/required message to be 'Enter the year'

### Why did it change

UCD requested changes.

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [OJ-2960](https://govukverify.atlassian.net/browse/OJ-2960)

## Screenshots

![image](https://github.com/user-attachments/assets/04559451-e965-4208-aff9-e8421420c749)
![image](https://github.com/user-attachments/assets/851924cb-1d30-4a3e-887f-7884435a8fd6)


[OJ-2960]: https://govukverify.atlassian.net/browse/OJ-2960?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ