### PR TITLE
Updating pre-commit hooks to latest versions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v5.0.0
     hooks:
       - id: check-added-large-files
         exclude: package-lock.json
@@ -12,12 +12,12 @@ repos:
       - id: trailing-whitespace
         exclude: .yarn
   - repo: https://github.com/Yelp/detect-secrets
-    rev: v1.4.0
+    rev: v1.5.0
     hooks:
       - id: detect-secrets
         args: ["--baseline", ".secrets.baseline"]
   - repo: https://github.com/pre-commit/mirrors-eslint
-    rev: v8.55.0
+    rev: v8.56.0
     hooks:
       - id: eslint
         files: \.[jt]sx?$ # *.js, *.jsx, *.ts and *.tsx
@@ -28,7 +28,7 @@ repos:
     hooks:
       - id: prettier
   - repo: https://github.com/aws-cloudformation/cfn-lint
-    rev: v0.83.3
+    rev: v1.22.0
     hooks:
       - id: cfn-lint
         files: .template\.ya?ml$

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -284,6 +284,11 @@ Resources:
 
   AddressFrontEcsService:
     Type: "AWS::ECS::Service"
+    Metadata:
+      cfn-lint:
+        config:
+          ignore_checks:
+            - E3056 #We want to remove load balancers if we are doing canary deployments
     Properties:
       Cluster: !Ref AddressFrontEcsCluster
       DeploymentConfiguration: !If


### PR DESCRIPTION
Not updated eslint as it requires a new config format

## Proposed changes
Updated pre-commit hook to latest versions except eslint, needed for cfnlint to recognise predicitive scaling as a valid property

### What changed
pre-commit hook versions

### Why did it change
see above