### PR TITLE
feat: fix aria label for language toggle

### DIFF
--- a/src/locales/en/default.yml
+++ b/src/locales/en/default.yml
@@ -37,7 +37,7 @@ govuk:
     tag: beta
     content: This is a new service – your <a href="https://home.account.gov.uk/contact-gov-uk-one-login" class="govuk-link" rel="noopener" target="_blank">feedback (opens in new tab)</a> will help us to improve it.
   languageToggle:
-    ariaLabel: Dewis iaith
+    ariaLabel: Choose a language
     englishLanguage: English
     englishVisuallyHidden: Change to English
     welshLanguage: Cymraeg


### PR DESCRIPTION
## Proposed changes

### What changed
The language toggle aria label

### Why did it change
It's meant to be in English when using the English translation.

### Issue tracking
- [OJ-2982](https://govukverify.atlassian.net/browse/OJ-2982)



[OJ-2982]: https://govukverify.atlassian.net/browse/OJ-2982?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ