### PR TITLE
OJ-2734: Adjust scaling policy

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -775,8 +775,11 @@ Resources:
       ServiceNamespace: ecs
       StepScalingPolicyConfiguration:
         AdjustmentType: PercentChangeInCapacity
-        Cooldown: 420
+        Cooldown: 300
         StepAdjustments:
+          - MetricIntervalUpperBound: -20
+            MetricIntervalLowerBound: -40
+            ScalingAdjustment: -10
           - MetricIntervalUpperBound: -40
             ScalingAdjustment: -50
 
@@ -791,9 +794,11 @@ Resources:
       ServiceNamespace: ecs
       StepScalingPolicyConfiguration:
         AdjustmentType: PercentChangeInCapacity
-        Cooldown: 120
+        Cooldown: 60
         MinAdjustmentMagnitude: 5
         StepAdjustments:
+          - MetricIntervalUpperBound: 20
+            ScalingAdjustment: 100
           - MetricIntervalLowerBound: 20
             MetricIntervalUpperBound: 30
             ScalingAdjustment: 200


### PR DESCRIPTION
## Proposed changes

### What changed

Scale Out
- Reduce cooldown from 120 seconds to 60
- Add Step adjustment for 60% - 80% to scale 100%

Scale In
- Reduce cooldown from 420 seconds to 300
- Add adjustment for 40% - 20% of 10%

### Why did it change

Implement a new ECS scaling policy is more robust than the existing based on information in the linked ticket. 

### Issue tracking

- [OJ-2734](https://govukverify.atlassian.net/browse/OJ-2734)

### Test

Tested using perf tests to trigger scaling and validate it still works, a full perf test will be needed to see if it improves performance.
Note: Max 4, Min 1 tasks in Dev

![image](https://github.com/user-attachments/assets/d3bd723b-443b-496c-afc3-749fb24c9437)
![image](https://github.com/user-attachments/assets/ffa65e07-a5a4-42d9-97c8-7ddfbb561a2d)
![image](https://github.com/user-attachments/assets/144b892a-b792-44ee-aa2c-c061c4957d85)

[OJ-2734]: https://govukverify.atlassian.net/browse/OJ-2734?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ