### PR TITLE
OJ-2870 configure ecs healthcheck

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,9 @@ ENV LD_PRELOAD /opt/dynatrace/oneagent/agent/lib64/liboneagentproc.so
 ENV PORT 8080
 EXPOSE $PORT
 
+HEALTHCHECK --interval=10s --timeout=2s --start-period=5s --retries=3 \
+  CMD curl -f http://localhost:$PORT/healthcheck || exit 1
+
 ENTRYPOINT ["tini", "--"]
 
 CMD ["yarn", "start"]

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -440,6 +440,14 @@ Resources:
               awslogs-group: !Ref ECSAccessLogsGroup
               awslogs-region: !Sub ${AWS::Region}
               awslogs-stream-prefix: !Sub address-front-${Environment}
+          HealthCheck:
+            Command:
+              - CMD-SHELL
+              - curl -f http://localhost:8080/healthcheck || exit 1 # If a HealthCheck returns a non-zero exit code, then it's considered unhealthy.
+            Interval: 10
+            Timeout:  2
+            Retries: 10 # This ensures that just one healthcheck failure won't cause the container to be drained and replaced.
+            StartPeriod: 0
       Cpu: "1024"
       ExecutionRoleArn: !GetAtt ECSTaskExecutionRole.Arn
       Memory: "2048"

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -445,7 +445,7 @@ Resources:
               - CMD-SHELL
               - curl -f http://localhost:8080/healthcheck || exit 1 # If a HealthCheck returns a non-zero exit code, then it's considered unhealthy.
             Interval: 10
-            Timeout:  2
+            Timeout: 2
             Retries: 10 # This ensures that just one healthcheck failure won't cause the container to be drained and replaced.
             StartPeriod: 0
       Cpu: "1024"

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -20,8 +20,10 @@ RUN yarn install --production --frozen-lockfile
 
 FROM --platform="linux/arm64" arm64v8/node@sha256:56e8282f4392fb96c877babc93b3829e46b79c6fbcd48c92de578febffc80587 AS final
 
-RUN ["apt-get", "update"]
-RUN ["apt-get", "install", "-y", "tini"]
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends curl tini \
+  && rm -rf /var/lib/apt/lists/*
+
 RUN [ "yarn", "set", "version", "1.22.17" ]
 
 WORKDIR /app
@@ -39,6 +41,9 @@ ENV LD_PRELOAD /opt/dynatrace/oneagent/agent/lib64/liboneagentproc.so
 
 ENV PORT 8080
 EXPOSE $PORT
+
+HEALTHCHECK --interval=10s --timeout=2s --start-period=5s --retries=3 \
+  CMD curl -f http://localhost:$PORT/healthcheck || exit 1
 
 ENTRYPOINT ["tini", "--"]
 

--- a/local.Dockerfile
+++ b/local.Dockerfile
@@ -12,6 +12,9 @@ COPY . ./
 
 RUN yarn build
 
+HEALTHCHECK --interval=10s --timeout=2s --start-period=5s --retries=3 \
+  CMD curl -f http://localhost:$PORT/healthcheck || exit 1
+
 CMD yarn run dev
 
 EXPOSE $PORT


### PR DESCRIPTION
## Proposed changes

**Before:** _No HealthCheck command configured_
![image](https://github.com/user-attachments/assets/0208c0fc-2541-4ad9-a3f9-0751890fcb18)

**After** _HealthCheck command configured_
![image](https://github.com/user-attachments/assets/51e6d671-d607-423f-8a53-f2538f263ba4)

### What changed

<!-- Describe the changes in detail - the "what"-->

### Why did it change

Currently load balancers are configured to call healthcheck endpoints to ensure that the target is healthy and ready to receive traffic, but also we need to implement configuration to for the task definition.
So as to enable it replace unhealthy tasks before the point of them being requested by the load balancer.

NB: 
The ECS TaskDefinition health is the primary mechanism ECS will use to monitor
ECS container health check, the healthcheck in the docker are mainly for consistency and local environment.
see note: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ecs-taskdefinition-healthcheck.html

### Issue tracking

- [OJ-2870](https://govukverify.atlassian.net/browse/OJ-2870)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->

- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[OJ-2870]: https://govukverify.atlassian.net/browse/OJ-2870?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ