### PR TITLE
feat: return err when there is an error set

### DIFF
--- a/src/app/address/controllers/address/nonUKAddress.js
+++ b/src/app/address/controllers/address/nonUKAddress.js
@@ -6,6 +6,9 @@ const { yearFrom, getCountry } = require("../../../../lib/helpers");
 const {
   buildingAddressComponent,
 } = require("../../components/buildingAddress");
+const { PACKAGE_NAME } = require("../../../../lib/config");
+
+const logger = require("hmpo-logger").get(PACKAGE_NAME);
 
 class NonUKAddressController extends BaseController {
   getValues(req, res, callback) {
@@ -36,6 +39,8 @@ class NonUKAddressController extends BaseController {
             visuallyHiddenText: "error",
           };
       }
+
+      logger.warn("Calling callback with err: " + err);
       callback(err, values);
     });
   }

--- a/src/app/address/controllers/address/whatCountry.js
+++ b/src/app/address/controllers/address/whatCountry.js
@@ -4,7 +4,7 @@ const BaseController = require("hmpo-form-wizard").Controller;
 const logger = require("hmpo-logger").get(PACKAGE_NAME);
 
 class WhatCountryController extends BaseController {
-  async getValues(req, res, callback) {
+  getValues(req, res, callback) {
     super.getValues(req, res, (err, values) => {
       values.country = "";
       if (err) {

--- a/src/app/address/controllers/address/whatCountry.js
+++ b/src/app/address/controllers/address/whatCountry.js
@@ -4,7 +4,11 @@ class WhatCountryController extends BaseController {
   async getValues(req, res, callback) {
     super.getValues(req, res, (err, values) => {
       values.country = "";
-      callback(err, values);
+      if (err) {
+        callback(err, values);
+      } else {
+        callback(null, values);
+      }
     });
   }
 }

--- a/src/app/address/controllers/address/whatCountry.js
+++ b/src/app/address/controllers/address/whatCountry.js
@@ -1,10 +1,14 @@
+const { PACKAGE_NAME } = require("../../../../lib/config");
 const BaseController = require("hmpo-form-wizard").Controller;
+
+const logger = require("hmpo-logger").get(PACKAGE_NAME);
 
 class WhatCountryController extends BaseController {
   async getValues(req, res, callback) {
     super.getValues(req, res, (err, values) => {
       values.country = "";
       if (err) {
+        logger.warn("Calling callback with err: " + err);
         callback(err, values);
       } else {
         callback(null, values);

--- a/src/app/address/controllers/address/whatCountry.test.js
+++ b/src/app/address/controllers/address/whatCountry.test.js
@@ -9,10 +9,6 @@ describe("whatCountryController", () => {
 
   beforeEach(() => {
     sandbox = sinon.createSandbox();
-
-    sandbox
-      .stub(BaseController.prototype, "getValues")
-      .callsFake((_, __, callback) => callback(null, {}));
     req = {
       sessionModel: {
         get: sandbox.stub(),
@@ -24,8 +20,42 @@ describe("whatCountryController", () => {
   afterEach(() => sandbox.restore());
 
   it("should set country to empty string", (done) => {
+    sandbox
+      .stub(BaseController.prototype, "getValues")
+      .callsFake((_, __, callback) => callback(null, {}));
+
     req.sessionModel.set("country", "test");
     address.getValues(req, res, (err, values) => {
+      expect(values.country).to.be.eq("");
+      done();
+    });
+  });
+
+  it("should call callback with error if there is one present", (done) => {
+    sandbox
+      .stub(BaseController.prototype, "getValues")
+      .callsFake((_, __, callback) => callback(error, {}));
+
+    const error = new Error("dummy-error");
+
+    req.sessionModel.set("country", "test");
+
+    address.getValues(req, res, (err, values) => {
+      expect(err).to.equal(error);
+      expect(values.country).to.be.eq("");
+      done();
+    });
+  });
+
+  it("should call callback without error if there is none present", (done) => {
+    sandbox
+      .stub(BaseController.prototype, "getValues")
+      .callsFake((_, __, callback) => callback(null, {}));
+
+    req.sessionModel.set("country", "test");
+
+    address.getValues(req, res, (err, values) => {
+      expect(err).to.equal(null);
       expect(values.country).to.be.eq("");
       done();
     });


### PR DESCRIPTION
## Proposed changes

### Why did it change
WhatCountryController has been changed to return the error with callback if its present. 

Looking at other uses of `async getValues` most cases use `callback(null, values)` or only set the err parameter when there is actually an error. 

Example when used when there is an error: https://github.com/govuk-one-login/ipv-cri-address-front/blob/10f17d519c2b90bf39154b6b948e2e6807394b4f/src/app/address/controllers/address/nonUKAddress.js#L39

Example using null: https://github.com/govuk-one-login/ipv-cri-address-front/blob/10f17d519c2b90bf39154b6b948e2e6807394b4f/src/app/address/controllers/address/manual.js#L55