### PR TITLE
OJ-2870: Update docker file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,8 +20,10 @@ RUN yarn install --production --frozen-lockfile
 
 FROM node:20.11.1-alpine3.19@sha256:f4c96a28c0b2d8981664e03f461c2677152cd9a756012ffa8e2c6727427c2bda AS final
 
-RUN ["apk", "--no-cache", "upgrade"]
-RUN ["apk", "add", "--no-cache", "tini"]
+RUN apk --no-cache upgrade \
+&& apk add --no-cache tini \
+&& apk add --no-cache curl
+
 RUN [ "yarn", "set", "version", "1.22.17" ]
 
 WORKDIR /app
@@ -35,9 +37,9 @@ COPY --from=builder /app/yarn.lock ./
 
 # Add in dynatrace layer
 COPY --from=khw46367.live.dynatrace.com/linux/oneagent-codemodules-musl:nodejs / /
-ENV LD_PRELOAD /opt/dynatrace/oneagent/agent/lib64/liboneagentproc.so
+ENV LD_PRELOAD=/opt/dynatrace/oneagent/agent/lib64/liboneagentproc.so
 
-ENV PORT 8080
+ENV PORT=8080
 EXPOSE $PORT
 
 HEALTHCHECK --interval=10s --timeout=2s --start-period=5s --retries=3 \

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -37,9 +37,9 @@ COPY --from=builder /app/yarn.lock ./
 
 # Add in dynatrace layer
 COPY --from=khw46367.live.dynatrace.com/linux/oneagent-codemodules-musl:nodejs / /
-ENV LD_PRELOAD /opt/dynatrace/oneagent/agent/lib64/liboneagentproc.so
+ENV LD_PRELOAD=/opt/dynatrace/oneagent/agent/lib64/liboneagentproc.so
 
-ENV PORT 8080
+ENV PORT=8080
 EXPOSE $PORT
 
 HEALTHCHECK --interval=10s --timeout=2s --start-period=5s --retries=3 \


### PR DESCRIPTION
## Proposed changes

In https://github.com/govuk-one-login/ipv-cri-address-front/pull/1061 
command to include curl was missing, and this caused the healthcheck to fail

### What changed

Added and updated Dockerfile with missing curl
command

### Why did it change

This is corrective change


- [OJ-2870](https://govukverify.atlassian.net/browse/OJ-2870)


[OJ-2870]: https://govukverify.atlassian.net/browse/OJ-2870?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ