### PR TITLE
OJ-2870: Address dockerfile warnings and linting errors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,39 +1,27 @@
-FROM node:20.11.1-alpine3.19@sha256:f4c96a28c0b2d8981664e03f461c2677152cd9a756012ffa8e2c6727427c2bda AS builder
+ARG NODE_SHA=sha256:f4c96a28c0b2d8981664e03f461c2677152cd9a756012ffa8e2c6727427c2bda
 
+FROM node:20.11.1-alpine3.19@${NODE_SHA} AS builder
 WORKDIR /app
 
-COPY .yarn ./.yarn
-COPY .yarnrc.yml ./
+COPY src/ ./src
+COPY .yarn/ ./.yarn
+COPY .yarnrc.yml yarn.lock package.json ./
 
-RUN [ "yarn", "set", "version", "1.22.17" ]
+RUN <<COMMANDS
+  yarn install --ignore-scripts --frozen-lockfile
+  yarn build
+  rm -rf node_modules/  # Only keep production packages
+  yarn install --production --ignore-scripts --frozen-lockfile
+COMMANDS
 
-COPY /src ./src
-COPY package.json yarn.lock ./
-
-RUN yarn install
-RUN yarn build
-
-# 'yarn install --production' does not prune test packages which are necessary
-# to build the app. So delete nod_modules and reinstall only production packages.
-RUN [ "rm", "-rf", "node_modules" ]
-RUN yarn install --production --frozen-lockfile
-
-FROM node:20.11.1-alpine3.19@sha256:f4c96a28c0b2d8981664e03f461c2677152cd9a756012ffa8e2c6727427c2bda AS final
-
-RUN apk --no-cache upgrade \
-&& apk add --no-cache tini \
-&& apk add --no-cache curl
-
-RUN [ "yarn", "set", "version", "1.22.17" ]
-
+FROM node:20.11.1-alpine3.19@${NODE_SHA} AS runner
+RUN apk --no-cache upgrade && apk add --no-cache tini curl
 WORKDIR /app
 
-# Copy in compile assets and deps from build container
+COPY --from=builder /app/package.json /app/yarn.lock ./
 COPY --from=builder /app/node_modules ./node_modules
 COPY --from=builder /app/dist ./dist
 COPY --from=builder /app/src ./src
-COPY --from=builder /app/package.json ./
-COPY --from=builder /app/yarn.lock ./
 
 # Add in dynatrace layer
 COPY --from=khw46367.live.dynatrace.com/linux/oneagent-codemodules-musl:nodejs / /
@@ -46,5 +34,4 @@ HEALTHCHECK --interval=10s --timeout=2s --start-period=5s --retries=3 \
   CMD curl -f http://localhost:$PORT/healthcheck || exit 1
 
 ENTRYPOINT ["tini", "--"]
-
 CMD ["yarn", "start"]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "di-ipv-cri-address-front",
   "description": "User interface for the Identity Proofing and Verification (IPV) system within the GDS digital identity platform, GOV.UK Sign In.",
+  "license": "MIT",
   "scripts": {
     "start": "node src/app.js",
     "start:ci": "NODE_ENV=development API_BASE_URL=http://127.0.0.1:8010/ LANGUAGE_TOGGLE_DISABLED=false yarn dev",

--- a/package.json
+++ b/package.json
@@ -84,5 +84,6 @@
     "strip-ansi": "^6.0.1",
     "string-width": "^4.2.2",
     "wrap-ansi": "^7.0.0"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }


### PR DESCRIPTION
- Add licence to package.json
- Join RUN commands
- Don't set yarn version as it's determined by the .yarnrc.yml file
- Use an ARG for the base image SHA

---

- Run yarn install
  Check in the lock file