### PR TITLE
OJ-2998: Fix - add label next to visually hidden label

### DIFF
--- a/src/views/address/enter-non-UK-address.njk
+++ b/src/views/address/enter-non-UK-address.njk
@@ -24,7 +24,7 @@
     </span>
     <a href="/what-country" data-id="changeCountry" class="govuk-link">
       Change<span class="govuk-visually-hidden">
-        {{ translate(links.changeCountry.title) }}</span>
+        {{ translate("links.changeCountry.label") }}</span>
     </a>
   </p>
 

--- a/src/views/components/address-year-from-field.njk
+++ b/src/views/components/address-year-from-field.njk
@@ -1,7 +1,7 @@
 {% macro yearFromField(ctx, params) %}
   {% from "hmpo-text/macro.njk" import hmpoText %}
 
-  <h4>{{ params.title }}</h4>
+  <h2 class="govuk-heading-s">{{ params.title }}</h2>
 
   {{ hmpoText(ctx, {
     id: params.name,

--- a/src/views/components/building-address/template.njk
+++ b/src/views/components/building-address/template.njk
@@ -97,7 +97,10 @@
   {% endif %}
 
   <div class="{%- if params.wrapper.classes %} {{ params.wrapper.classes }}{% endif %}">
+  {% set listHintId = 'building-address-hint' %}
+  <ol class="govuk-list" aria-describedby="{{ listHintId }}">
   {% for individualInput in params.inputs %}
+  <li>
     <div class="{{ 'govuk-!-margin-bottom-5' if not loop.last }} {{ 'govuk-form-group--error' if individualInput.errorMessage and individualInput.errorMessage.text and individualInput.errorMessage.text | trim }}">
       {{ govukLabel({
         html: individualInput.label.html,
@@ -133,7 +136,9 @@
 
       {{ _inputElement(individualInput, params) }}
     </div>
+  </li>
   {% endfor %}
+  </ol>
 
   </div>
 </div>


### PR DESCRIPTION
## Proposed changes

### What changed

1. Add label text next to visually hidden class
Previous:
<img width="481" alt="Screenshot 2025-01-16 at 13 34 58" src="https://github.com/user-attachments/assets/0a310aa0-5e0f-4dd2-ac2f-f1157f02a2f4" />

Current:
<img width="1374" alt="Screenshot 2025-01-16 at 14 38 23" src="https://github.com/user-attachments/assets/57f79d72-3034-4c8b-8a9f-318628325c2f" />

2. Updated the `When did you start living at this address?` to H2 and new class
Previous:
<img width="1290" alt="Screenshot 2025-01-16 at 14 44 59" src="https://github.com/user-attachments/assets/169eee68-1cdc-49c6-a8d5-aa659db01e0c" />

Current:
<img width="1351" alt="Screenshot 2025-01-16 at 14 44 33" src="https://github.com/user-attachments/assets/c12926ee-0e9f-4135-b008-3b40253d1a8b" />

3. Add extra HMTL semantic markup and added aria-describedby to hint label

Previous: 
<img width="1373" alt="Screenshot 2025-01-17 at 15 16 00" src="https://github.com/user-attachments/assets/0b118c83-c11b-47a8-b5e2-5fc935f8c8bd" />

Current:
<img width="1364" alt="image" src="https://github.com/user-attachments/assets/7b247928-4008-40bc-a06d-98245b6b6de5" />


### Why did it change

Based on accessibility fixes found during audit

### Issue tracking

- [OJ-2998](https://govukverify.atlassian.net/browse/OJ-2998)

## Checklists

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[OJ-2998]: https://govukverify.atlassian.net/browse/OJ-2998?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ