### PR TITLE
PYIC-7942: Revert staging log level back to warn

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -81,8 +81,7 @@ Mappings:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
       minECSCount: 2
       maxECSCount: 4
-      # Temporarily to debug an issue seen in staging
-      logLevel: "debug"
+      logLevel: "warn"
     integration:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
       minECSCount: 2


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Revert staging log level back to warn

### Why did it change

We are finished debugging

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-7942](https://govukverify.atlassian.net/browse/PYIC-7942)


[PYIC-7942]: https://govukverify.atlassian.net/browse/PYIC-7942?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ