### PR TITLE
fix(dfc-717): add data attributes for navigation tracking

### DIFF
--- a/src/views/address/address.njk
+++ b/src/views/address/address.njk
@@ -23,7 +23,7 @@
     {% include "../components/address-input-fields.njk" %}
     {{ yearFromField(ctx, { name: "addressYearFrom", title: title, label: label }) }}
 
-    {{ hmpoSubmit(ctx, {id: "continue", text: translate("buttons.next")}) }}
+    {{ hmpoSubmit(ctx, {attributes: {"data-nav": true, "data-link": "/undefined"}, id: "continue", text: translate("buttons.next")}) }}
 
   {% endcall %}
 

--- a/src/views/address/results.njk
+++ b/src/views/address/results.njk
@@ -24,7 +24,7 @@
 
     {{ hmpoHtml(translate("links.cantFindAddress")) }}
 
-    {{ hmpoSubmit(ctx, {id: "continue", text: translate("buttons.select-address")}) }}
+    {{ hmpoSubmit(ctx, {id: "continue", attributes: {"data-nav": true, "data-link": "/undefined"}, text: translate("buttons.select-address")}) }}
 
   {% endcall %}
 

--- a/src/views/address/search.njk
+++ b/src/views/address/search.njk
@@ -32,7 +32,10 @@
       autocomplete: "postal-code"
     }) }}
 
-    {{ hmpoSubmit(ctx, {id: "continue", text: translate("buttons.find-address")}) }}
+    {{ hmpoSubmit(ctx, {
+      id: "continue",
+      attributes: { "data-nav": true, "data-link": "/results" },
+      text: translate("buttons.find-address")}) }}
     {%- include "../components/continue-submit-spinner.njk" -%}
 
   {% endcall %}

--- a/src/views/components/address-confirm.njk
+++ b/src/views/components/address-confirm.njk
@@ -151,9 +151,11 @@
         text: translate("pages.address-confirm.buttons.next"),
         id: "continue",
         attributes: {
-        "data-id": "next"
-      }
-    }) }}
+        "data-id": "next",
+        "data-nav": true,
+        "data-link": "/undefined"
+        }
+      }) }}
     {%- include "../components/continue-submit-spinner.njk" -%}
 
   {% endcall %}

--- a/src/views/components/address-problem-field.njk
+++ b/src/views/components/address-problem-field.njk
@@ -19,7 +19,7 @@
     })
   }}
 
-  {{ hmpoSubmit(ctx, {id: "continue", text: translate("buttons.next")}) }}
+  {{ hmpoSubmit(ctx, {attributes: {"data-nav": true, "data-link": "/undefined"}, id: "continue", text: translate("buttons.next")}) }}
 
  {{hmpoHtml(translate("links.helpContact"))}}
 

--- a/src/views/previous/address.njk
+++ b/src/views/previous/address.njk
@@ -17,7 +17,7 @@
 
     {% include "../components/address-input-fields.njk" %}
 
-    {{ hmpoSubmit(ctx, {id: "continue", text: translate("buttons.next")}) }}
+    {{ hmpoSubmit(ctx, {attributes: {"data-nav": true, "data-link": "/undefined"}, id: "continue", text: translate("buttons.next")}) }}
 
   {% endcall %}
   {{ ga4OnPageLoad({

--- a/src/views/previous/results.njk
+++ b/src/views/previous/results.njk
@@ -25,7 +25,7 @@
 
     {{ hmpoHtml(translate("links.previous.cantFindAddress")) }}
 
-    {{ hmpoSubmit(ctx, {id: "continue", text: translate("buttons.select-address")}) }}
+    {{ hmpoSubmit(ctx, {attributes: {"data-nav": true, "data-link": "/previous-address-check"}, id: "continue", text: translate("buttons.select-address")}) }}
 
   {% endcall %}
 

--- a/src/views/previous/search.njk
+++ b/src/views/previous/search.njk
@@ -22,7 +22,7 @@
       hint:  translate("fields.addressSearch.previous.hint")
     }) }}
 
-    {{ hmpoSubmit(ctx, {id:"continue", text: translate("buttons.find-address")}) }}
+    {{ hmpoSubmit(ctx, {id:"continue", attributes: {"data-nav": true, "data-link": "/previous-results"}, text: translate("buttons.find-address")}) }}
 
   {% endcall %}
 


### PR DESCRIPTION
## Proposed changes

### What changed

`data-nav` and `data-link` have been added to `hmpoSubmit` components for analytics navigation tracking 

### Why did it change

Without these data attributes, the navigation tracker will not fire

### Issue tracking

- [DFC-717](https://govukverify.atlassian.net/browse/DFC-717)

## Checklists

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed


[DFC-717]: https://govukverify.atlassian.net/browse/DFC-717?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ