### PR TITLE
OJ-2999: Change max length to validation only

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -6,7 +6,7 @@ sonar.sources=src/
 sonar.exclusions=\
   src/assets/**,\
   src/**/*.test.js,\
-  src/app/**/fields.js\
+  src/app/**/fields.js,\
   src/app/**/*Fields.js,\
   src/app/**/steps.js,\
   src/app/**/index.js,\

--- a/src/app/address/routes/sharedFields.js
+++ b/src/app/address/routes/sharedFields.js
@@ -10,6 +10,8 @@ const {
   isPreviousYear,
 } = require("../validators/addressValidator");
 
+const { underMaxLength } = require("../validators/underMaxLengthValidator");
+
 module.exports = {
   addressSearch: {
     type: "text",
@@ -119,6 +121,11 @@ module.exports = {
     type: "text",
     validate: [
       {
+        type: "underMaxLength",
+        fn: underMaxLength,
+        arguments: 30,
+      },
+      {
         type: "alphaNumericWithSpecialChars",
         fn: alphaNumericWithSpecialChars,
       },
@@ -127,6 +134,11 @@ module.exports = {
   nonUKAddressBuildingNumber: {
     type: "text",
     validate: [
+      {
+        type: "underMaxLength",
+        fn: underMaxLength,
+        arguments: 30,
+      },
       {
         type: "alphaNumericWithSpecialChars",
         fn: alphaNumericWithSpecialChars,
@@ -137,6 +149,11 @@ module.exports = {
     type: "text",
     validate: [
       {
+        type: "underMaxLength",
+        fn: underMaxLength,
+        arguments: 50,
+      },
+      {
         type: "alphaNumericWithSpecialChars",
         fn: alphaNumericWithSpecialChars,
       },
@@ -146,9 +163,9 @@ module.exports = {
     type: "text",
     validate: [
       {
-        type: "maxlength",
-        fn: "maxlength",
-        arguments: [60],
+        type: "underMaxLength",
+        fn: underMaxLength,
+        arguments: 60,
       },
       {
         type: "alphaNumericWithSpecialChars",
@@ -163,9 +180,9 @@ module.exports = {
         type: "required",
       },
       {
-        type: "maxlength",
-        fn: "maxlength",
-        arguments: [60],
+        type: "underMaxLength",
+        fn: underMaxLength,
+        arguments: 60,
       },
       {
         type: "alphaNumericWithSpecialChars",
@@ -177,9 +194,9 @@ module.exports = {
     type: "text",
     validate: [
       {
-        type: "maxlength",
-        fn: "maxlength",
-        arguments: [10],
+        type: "underMaxLength",
+        fn: underMaxLength,
+        arguments: 15,
       },
       {
         type: "alphaNumericWithSpecialChars",
@@ -191,9 +208,9 @@ module.exports = {
     type: "text",
     validate: [
       {
-        type: "maxlength",
-        fn: "maxlength",
-        arguments: [60],
+        type: "underMaxLength",
+        fn: underMaxLength,
+        arguments: 60,
       },
       {
         type: "alphaNumericWithSpecialChars",

--- a/src/app/address/validators/underMaxLengthValidator.js
+++ b/src/app/address/validators/underMaxLengthValidator.js
@@ -1,0 +1,10 @@
+module.exports = {
+  /*
+  We need to use a custom max length validator for hmpoText fields.
+  Having a validator type of maxlength causes hmpoText components to set the maxlength HTML attribute.
+  This causes accessibility issues.
+  */
+  underMaxLength: function (val, max) {
+    return val.length <= max;
+  },
+};

--- a/src/app/address/validators/underMaxLengthValidator.test.js
+++ b/src/app/address/validators/underMaxLengthValidator.test.js
@@ -1,0 +1,13 @@
+const { underMaxLength } = require("./underMaxLengthValidator");
+
+describe("underMaxLengthValidator", () => {
+  it("should return true when under max length", () => {
+    const result = underMaxLength("UnderTen", 10);
+    expect(result).to.equal(true);
+  });
+
+  it("should return false when over max length", () => {
+    const result = underMaxLength("OverTennnnn", 10);
+    expect(result).to.equal(false);
+  });
+});

--- a/src/locales/cy/fields.yml
+++ b/src/locales/cy/fields.yml
@@ -39,41 +39,44 @@ addressLocality:
 nonUKAddressApartmentNumber:
   label: "Rhif fflat"
   validation:
+    underMaxLength: "Rhaid i'r rhif fflat fod yn 30 nod neu lai"
     alphaNumericWithSpecialChars: "Rhaid i rif y fflat ond cynnwys rhifau 0 i 9, llythrennau a i z a .,-\/* neu '"
 
 nonUKAddressBuildingNumber:
   label: "Rhif adeilad"
   validation:
+    underMaxLength: "Rhaid i'r rhif adeilad fod yn 30 nod neu lai"
     alphaNumericWithSpecialChars: "Rhaid i rif yr adeilad ond cynnwys rhifau 0 i 9, llythrennau a i z a .,-\/* neu '"
 
 nonUKAddressBuildingName:
   label: "Enw adeilad"
   validation:
+    underMaxLength: "Rhaid i'r enw adeilad fod yn 50 nod neu lai"
     alphaNumericWithSpecialChars: "Rhaid i enw'r adeilad ond cynnwys rhifau 0 i 9, llythrennau a i z a .,-\/* neu '"
 
 nonUKAddressStreetName:
   label: "Enw stryd (dewisol)"
   validation:
-    maxlength: "Gwiriwch eich bod wedi rhoi enw eich stryd yn gywir"
+    underMaxLength: "Rhaid i'r enw stryd fod yn 60 nod neu lai"
     alphaNumericWithSpecialChars: "Rhaid i enw'r stryd ond cynnwys rhifau 0 i 9, llythrennau a i z a .,-\/* neu '"
 
 nonUKAddressLocality:
   label: "Tref, maestref neu ddinas"
   validation:
-    maxlength: "Gwiriwch eich bod wedi rhoi enw eich tref, maestref neu ddinas yn gywir"
+    underMaxLength: "Rhaid i'r dref, y faestref neu'r ddinas fod yn 60 nod neu lai"
     alphaNumericWithSpecialChars: "Rhaid i enw'r tref, maestref neu ddinas ond cynnwys rhifau 0 i 9, llythrennau a i z a .,-\/* neu '"
 
 nonUKAddressPostalCode:
   label: "Cod post neu god zip (os oes gan eich gwlad un)"
   validation:
-    maxlength: "Gwiriwch eich bod wedi rhoi eich cod post neu god zip yn gywir"
+    underMaxLength: "Rhaid i'r cod post neu'r cod zip fod yn 15 nod neu lai"
     alphaNumericWithSpecialChars: "Rhaid i god post neu god zip ond cynnwys rhifau 0 i 9, llythrennau a i z a .,-\/* neu '"
 
 nonUKAddressRegion:
   label: "Rhanbarth (dewisol)"
   hint: "Er enghraifft, gwlad, ardal, sir, plwyf neu dalaith"
   validation:
-    maxlength: "Gwiriwch eich bod wedi rhoi eich rhanbarth yn gywir"
+    underMaxLength: "Rhaid i'r rhanbarth fod yn 60 nod neu lai"
     alphaNumericWithSpecialChars: "Rhaid i rhanbarth ond cynnwys rhifau 0 i 9, llythrennau a i z a .,-\/* neu '"
 
 nonUKAddressYearFrom:

--- a/src/locales/en/fields.yml
+++ b/src/locales/en/fields.yml
@@ -45,41 +45,44 @@ addressLocality:
 nonUKAddressApartmentNumber:
   label: Apartment number
   validation:
+    underMaxLength: Apartment number must be 30 characters or less
     alphaNumericWithSpecialChars: Apartment number must only include numbers 0 to 9, letters a to z and .,-\/* or '
 
 nonUKAddressBuildingNumber:
   label: Building number
   validation:
+    underMaxLength: Building number must be 30 characters or less
     alphaNumericWithSpecialChars: Building number must only include numbers 0 to 9, letters a to z and .,-\/* or '
 
 nonUKAddressBuildingName:
   label: Building name
   validation:
+    underMaxLength: Building name must be 50 characters or less
     alphaNumericWithSpecialChars: Building name must only include letters a to z, numbers 0 to 9 and .,-\/* or '
 
 nonUKAddressStreetName:
   label: Street name (optional)
   validation:
-    maxlength: Check you've entered your street name correctly
+    underMaxLength: Street name must be 60 characters or less
     alphaNumericWithSpecialChars: Street name must only include letters a to z, numbers 0 to 9 and .,-\/* or '
 
 nonUKAddressLocality:
   label: Town, suburb or city
   validation:
-    maxlength: Check you've entered your town, suburb or city correctly
+    underMaxLength: Town, suburb or city must be 60 characters or less
     alphaNumericWithSpecialChars: Town, suburb or city must only include letters a to z, numbers 0 to 9 and .,-\/* or '
 
 nonUKAddressPostalCode:
   label: Postal code or zipcode (if your country has one)
   validation:
-    maxlength: Check you've entered your postal code or zipcode correctly
+    underMaxLength: Postal code or zipcode must be 15 characters or less
     alphaNumericWithSpecialChars: Postal code or zipcode must only include numbers 0 to 9, letters a to z and .,-\/* or '
 
 nonUKAddressRegion:
   label: Region (optional)
   hint: For example, state, district, county, parish or province
   validation:
-    maxlength: Check you've entered your region correctly
+    underMaxLength: Region must be 60 characters or less
     alphaNumericWithSpecialChars: Region must only include letters a to z, numbers 0 to 9 and .,-\/* or '
 
 addressYearFrom:

--- a/test/browser/features/international-address-enter-address.feature
+++ b/test/browser/features/international-address-enter-address.feature
@@ -160,6 +160,27 @@ Feature: International address - Enter your address
     Then they see an error summary with failed validation message: "Region must only include letters a to z, numbers 0 to 9 and .,-\/* or '"
     Then they see an error summary with failed validation message: "Town, suburb or city must only include letters a to z, numbers 0 to 9 and .,-\/* or '"
 
+  Scenario: Enter international address details fails validation when fields are too long
+    Given they have selected the country "Kenya"
+    When they click the continue button
+    Then they should see international address form
+    When they add their building address apartment number "1234567890123456789012345678901"
+    And they add their building address name "123456789012345678901234567890123456789012345678901"
+    And they add their building address number "1234567890123456789012345678901"
+    And they add their international street "1234567890123456789012345678901234567890123456789012345678901"
+    And they add their town, suburb or city "1234567890123456789012345678901234567890123456789012345678901"
+    And they add their Postal code or zipcode "1234567890123456"
+    And they add their Region "1234567890123456789012345678901234567890123456789012345678901"
+    And they add the "older" year they started living at this address
+    And they continue to confirm international address
+    Then they see an error summary with failed validation message: "Apartment number must be 30 characters or less"
+    Then they see an error summary with failed validation message: "Building number must be 30 characters or less"
+    Then they see an error summary with failed validation message: "Building name must be 50 characters or less"
+    Then they see an error summary with failed validation message: "Street name must be 60 characters or less"
+    Then they see an error summary with failed validation message: "Postal code or zipcode must be 15 characters or less"
+    Then they see an error summary with failed validation message: "Region must be 60 characters or less"
+    Then they see an error summary with failed validation message: "Town, suburb or city must be 60 characters or less"
+
   Scenario: Change selected international country, selected same country leads to international page
     Given they have selected the country "Kenya"
     When they click the continue button


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Currently on the international address form, maxLength is set as a HTML property and stops users inputting char's over that length.

This PR adds our own validator 'underMaxLength', that will just do validation on the field and not add the maxlength HTML property to it.

Fix: `sonar-project.properties` was missing a comma so the `sharedFields.js` was being included in test coverage which was failing on this PR.

### Why did it change

To ensure that the international address form adheres to accessibility standards.

### Issue tracking

- [OJ-2999](https://govukverify.atlassian.net/browse/OJ-2999)

### Screenshots

![image](https://github.com/user-attachments/assets/a0387554-8fe9-45ec-a227-af5cd1a51bd1)
![image](https://github.com/user-attachments/assets/5efae4ba-bbdf-414a-b0aa-72b7c3966a57)
![image](https://github.com/user-attachments/assets/2dc93ed5-cd38-470b-809b-53ca291b3caa)



[OJ-2999]: https://govukverify.atlassian.net/browse/OJ-2999?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ