### PR TITLE
OJ-2998: Fix - add role to fix Safari voiceOver

### DIFF
--- a/src/views/components/building-address/template.njk
+++ b/src/views/components/building-address/template.njk
@@ -98,7 +98,7 @@
 
   <div class="{%- if params.wrapper.classes %} {{ params.wrapper.classes }}{% endif %}">
   {% set listHintId = 'building-address-hint' %}
-  <ol class="govuk-list" aria-describedby="{{ listHintId }}">
+  <ol class="govuk-list" role="list" aria-describedby="{{ listHintId }}">
   {% for individualInput in params.inputs %}
   <li>
     <div class="{{ 'govuk-!-margin-bottom-5' if not loop.last }} {{ 'govuk-form-group--error' if individualInput.errorMessage and individualInput.errorMessage.text and individualInput.errorMessage.text | trim }}">


### PR DESCRIPTION

### What changed

Add `role="list"` to the `<ol>` tag to fix Safari voiceOver

### Why did it change

Based on the known issue [here](https://govtnz.github.io/web-a11y-guidance/wct/lists/make-a-list-accessible.html#other-accessibility-considerations) from Derren's retest Safari did not announce the listed items 

Chrome worked as expected.

### Issue tracking

- [OJ-2998](https://govukverify.atlassian.net/browse/OJ-2998)

## Checklists

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed



[OJ-2998]: https://govukverify.atlassian.net/browse/OJ-2998?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ