### PR TITLE
OJ-2999: Add autocomplete on to all int address form fields

### DIFF
--- a/src/views/components/address-year-from-field.njk
+++ b/src/views/components/address-year-from-field.njk
@@ -11,6 +11,6 @@
     hint: "",
     type: "text",
     inputmode: "numeric",
-    attributes: { "spellcheck": "false" }
+    attributes: { "spellcheck": "false", "autocomplete": "on" }
   }) }}
 {% endmacro %}

--- a/src/views/components/building-address/non-UK-building-address-input.njk
+++ b/src/views/components/building-address/non-UK-building-address-input.njk
@@ -18,7 +18,8 @@
       label: { text: translate("fields.nonUKAddressApartmentNumber.label") },
       classes: "govuk-input--width-5",
       value: values.nonUKAddressApartmentNumber,
-      errorMessage: values.errors.nonUKAddressApartmentNumber
+      errorMessage: values.errors.nonUKAddressApartmentNumber,
+      autocomplete: "on"
     },
     {
       id: "nonUKAddressBuildingNumber",
@@ -26,7 +27,8 @@
       label: { text: translate("fields.nonUKAddressBuildingNumber.label") },
       classes: "govuk-input--width-5",
       value: values.nonUKAddressBuildingNumber,
-      errorMessage: values.errors.nonUKAddressBuildingNumber
+      errorMessage: values.errors.nonUKAddressBuildingNumber,
+      autocomplete: "on"
     },
     {
       id: "nonUKAddressBuildingName",
@@ -34,7 +36,8 @@
       label: { text: translate("fields.nonUKAddressBuildingName.label") },
       classes: "govuk-input--width-20",
       value: values.nonUKAddressBuildingName,
-      errorMessage: values.errors.nonUKAddressBuildingName
+      errorMessage: values.errors.nonUKAddressBuildingName,
+      autocomplete: "on"
     }
   ]
 } )

--- a/src/views/components/non-UK-address-input-fields.njk
+++ b/src/views/components/non-UK-address-input-fields.njk
@@ -33,5 +33,6 @@
       name: "nonUKAddressRegion",
       label: { text: translate("fields.nonUKAddressRegion.label") },
       classes: "govuk-input--width-20",
-      hint: { text: translate("fields.nonUKAddressRegion.hint") }
+      hint: { text: translate("fields.nonUKAddressRegion.hint") },
+      autocomplete: "on"
     }) }}


### PR DESCRIPTION
## Proposed changes

### What changed

hmpoForm has autocomplete hardcoded to off. Instead of creating our own form component, add autocomplete individually to the remaining inputs without autocomplete already set.

This has only be applied to the enter-non-UK-address form and both address form year inputs (shared component)

See hmpoForm here: https://github.com/HMPO/hmpo-components/blob/f1036ee824dff7fec95277e338e2a5fb7489b4ae/components/hmpo-form/macro.njk#L8
Evidence linked PR in the ticket (UK Address) does not actually work and has `autocomplete: off`
![image](https://github.com/user-attachments/assets/3f4f07c1-7860-4937-a6f2-e366478fcd51)

### Why did it change

Ensure that autocomplete works across the international address form, allowing users to fill in details faster if saved information is available.

### Issue tracking

- [OJ-2999](https://govukverify.atlassian.net/browse/OJ-2999)

### Screenshots

![image](https://github.com/user-attachments/assets/2ed09a57-5f54-49d9-9609-f84aa7a00405)


[OJ-2999]: https://govukverify.atlassian.net/browse/OJ-2999?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ