### PR TITLE
DCP-4451 Increase vCPU to 2, to help speed up main eventLoop

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -447,9 +447,9 @@ Resources:
             Timeout: 2
             Retries: 10 # This ensures that just one healthcheck failure won't cause the container to be drained and replaced.
             StartPeriod: 0
-      Cpu: "1024"
+      Cpu: "2048"
       ExecutionRoleArn: !GetAtt ECSTaskExecutionRole.Arn
-      Memory: "2048"
+      Memory: "4096"
       NetworkMode: awsvpc
       RequiresCompatibilities:
         - FARGATE


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Increased cpu of the ECS container to 2048 units, also increased memory to 4096 to be compatible.

### Why did it change

The main eventLoop is slowing under load, more CPUs allow async processes to execute in a second cpu off the main thread.

### Issue tracking


## Checklists

