### PR TITLE
OJ-1161: Fix - updated presented to remove extra line space when flat…

### DIFF
--- a/src/app/address/controllers/summary/confirm.test.js
+++ b/src/app/address/controllers/summary/confirm.test.js
@@ -47,10 +47,9 @@ describe("Address confirmation controller", () => {
     it("Should format the current address and previous addresses in locals", async () => {
       // factor in the address might have building name or number or both
       const params = {
-        currentAddressRowValue:
-          "flat 1<br>1 street1,<br>town1,<br>postcode1<br>",
+        currentAddressRowValue: "flat 1<br>1 street1<br>town1<br>postcode1",
         validFromRow: String(new Date().getFullYear()),
-        previousAddressRowValue: "farm2,<br>town2,<br>postcode2<br>",
+        previousAddressRowValue: "farm2<br>town2<br>postcode2",
         changeCurrentHref: "/address/edit?edit=true",
       };
 

--- a/src/presenters/addressPresenter.js
+++ b/src/presenters/addressPresenter.js
@@ -27,11 +27,25 @@ module.exports = {
 
     const fullLocality = localityNames.join(" ");
 
-    if (fullStreetName) {
-      return `${fullBuildingName}<br>${fullStreetName},<br>${fullLocality},<br>${address.postalCode}<br>`;
-    } else {
-      return `${fullBuildingName},<br>${fullLocality},<br>${address.postalCode}<br>`;
+    let addressConfirm = [];
+
+    if (fullBuildingName) {
+      addressConfirm.push(fullBuildingName);
     }
+
+    if (fullStreetName) {
+      addressConfirm.push(fullStreetName);
+    }
+
+    if (fullLocality) {
+      addressConfirm.push(fullLocality);
+    }
+
+    if (address.postalCode) {
+      addressConfirm.push(address.postalCode);
+    }
+
+    return addressConfirm.join("<br>");
   },
   generateHTMLofNonUKAddress: function (translate, address) {
     const countryList = require("../app/address/data/countries.json");

--- a/src/presenters/addressPresenter.test.js
+++ b/src/presenters/addressPresenter.test.js
@@ -81,9 +81,7 @@ describe("Generate HTML of address", () => {
         ].join("<br>"),
         localityText,
         address.postalCode,
-      ]
-        .join(",<br>")
-        .concat("<br>")
+      ].join("<br>")
     );
   });
 
@@ -100,9 +98,7 @@ describe("Generate HTML of address", () => {
         ].join("<br>"),
         localityText,
         address.postalCode,
-      ]
-        .join(",<br>")
-        .concat("<br>")
+      ].join("<br>")
     );
   });
 });

--- a/test/browser/features/address-manual-rfc-0020-address-structure-compliance.feature
+++ b/test/browser/features/address-manual-rfc-0020-address-structure-compliance.feature
@@ -19,8 +19,8 @@ Feature: compliance for address structures presented in https://github.com/alpha
     And they continue to confirm address
     Then they should see the confirm page
     And they should see the address value "Flat 1"
-    And they should see the address value "87 Zzz Way,"
-    And they should see the address value "Whitehouse Milton Keynes,"
+    And they should see the address value "87 Zzz Way"
+    And they should see the address value "Whitehouse Milton Keynes"
     And they should see the address value "ZZ1 1ZZ"
 
 
@@ -38,7 +38,7 @@ Feature: compliance for address structures presented in https://github.com/alpha
     And they continue to confirm address
     Then they should see the confirm page
     And they should see the address value "Flat 11 Blashford<br>Zzz Road"
-    And they should see the address value "London,"
+    And they should see the address value "London"
     And they should see the address value "ZZ1 1ZZ"
 
   Scenario: Show neither flat number nor house number
@@ -55,8 +55,8 @@ Feature: compliance for address structures presented in https://github.com/alpha
     And they continue to confirm address
     Then they should see the confirm page
     And they should see the address value "Zzz Marina"
-    And they should see the address value "Zzz Road,"
-    And they should see the address value "Long Zzz Nottingham,"
+    And they should see the address value "Zzz Road"
+    And they should see the address value "Long Zzz Nottingham"
     And they should see the address value "ZZ1 1ZZ"
 
 
@@ -74,8 +74,8 @@ Feature: compliance for address structures presented in https://github.com/alpha
     And they continue to confirm address
     Then they should see the confirm page
     And they should see the address value "Zzz Group Unit 2b Zzz Business Park"
-    And they should see the address value "16 Zzz Park Zzz Street,"
-    And they should see the address value "Some Zzz Long Eaton Great Missenden,"
+    And they should see the address value "16 Zzz Park Zzz Street"
+    And they should see the address value "Some Zzz Long Eaton Great Missenden"
     And they should see the address value "ZZ1 1ZZ"
 
   Scenario: no uprn is ok
@@ -92,8 +92,8 @@ Feature: compliance for address structures presented in https://github.com/alpha
     And they continue to confirm address
     Then they should see the confirm page
     And they should see the address value "R103"
-    And they should see the address value "Zzz Park Creek Road,"
-    And they should see the address value "Zzz Island,"
+    And they should see the address value "Zzz Park Creek Road"
+    And they should see the address value "Zzz Island"
     And they should see the address value "ZZ1 1ZZ"
 
   Scenario: dependent address locality is not editable
@@ -110,8 +110,8 @@ Feature: compliance for address structures presented in https://github.com/alpha
     And they continue to confirm address
     Then they should see the confirm page
     And they should see the address value "13"
-    And they should see the address value "Zzz Crescent,"
-    And they should see the address value "New Pitsligo Fraserburgh,"
+    And they should see the address value "Zzz Crescent"
+    And they should see the address value "New Pitsligo Fraserburgh"
     And they should see the address value "ZZ1 1ZZ"
 
   Scenario: organisation name and dependent street name is not editable
@@ -128,6 +128,6 @@ Feature: compliance for address structures presented in https://github.com/alpha
     And they continue to confirm address
     Then they should see the confirm page
     And they should see the address value "3"
-    And they should see the address value "Zzz Walk,"
-    And they should see the address value "Middlesbrough,"
+    And they should see the address value "Zzz Walk"
+    And they should see the address value "Middlesbrough"
     And they should see the address value "ZZ1 1ZZ"

--- a/test/browser/features/flat-number.feature
+++ b/test/browser/features/flat-number.feature
@@ -18,7 +18,7 @@ Background:
       And they add their city "London"
       And they add their residency date with a "older" move year
       And they continue to confirm address
-      Then they should see the address value "17<br>115 Downing Street,<br>"
+      Then they should see the address value "17<br>115 Downing Street<br>"
 
     Scenario: Testing flat number on edit. Adding flat number and house name
       Given they are on the address page
@@ -28,7 +28,7 @@ Background:
       And they add their city "London"
       And they add their residency date with a "older" move year
       And they continue to confirm address
-      Then they should see the address value "17 house<br>Downing Street,<br>"
+      Then they should see the address value "17 house<br>Downing Street<br>"
 
     Scenario: Testing flat number on edit. Adding flat number, house name and house number
       Given they are on the address page
@@ -39,4 +39,4 @@ Background:
       And they add their city "London"
       And they add their residency date with a "older" move year
       And they continue to confirm address
-      Then they should see the address value "17 house<br>115 Downing Street,<br>"
+      Then they should see the address value "17 house<br>115 Downing Street<br>"


### PR DESCRIPTION
## Proposed changes

### What changed

- Updated the presenter view on confirm your address screen to ensure extra line spacing was removed
- Confirmed with UCD that commas should be removed after each line [here](https://www.figma.com/design/nglBHtbzJYEeST43Iu1jW3/Identity-Pod---UCD-Hive?node-id=25784-61486&p=f)
- Updated unit and feature tests to remove comma and additional break tags at the end

## Kenneth D - address:
![Screenshot 2025-01-29 at 09 07 27](https://github.com/user-attachments/assets/5e44a071-9fc7-43ef-8174-ef3ed7c1105b)


## All fields populated address:
![Screenshot 2025-01-29 at 09 07 44](https://github.com/user-attachments/assets/dbd01477-9d1f-4f5d-bad1-7c92dbd0645e)


## Minimum required fields populated:
![Screenshot 2025-01-29 at 09 08 03](https://github.com/user-attachments/assets/3a559ad0-7a61-42eb-a70b-bc621c11e4bb)


## All required fields populated:
![Screenshot 2025-01-29 at 09 08 17](https://github.com/user-attachments/assets/c41bf30c-da61-4c73-93f2-4cdd7b1abbc6)


## Loads of characters:
![Screenshot 2025-01-29 at 09 09 35](https://github.com/user-attachments/assets/e40486fb-40d2-4a62-9a40-ad29b4f8092a)



### Why did it change
Based on the accessibility testing

### Issue tracking

- [OJ-1161](https://govukverify.atlassian.net/browse/OJ-1161)

## Checklists

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed


[OJ-1161]: https://govukverify.atlassian.net/browse/OJ-1161?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ