### PR TITLE
OJ-2871: Fix - prevent SIGTERM being called twice

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -209,5 +209,7 @@ process.on("SIGTERM", () => {
       // eslint-disable-next-line no-console
       console.log("HTTP server closed");
     }
+
+    process.exit(0);
   });
 });


### PR DESCRIPTION


## Proposed changes

### What changed

- Added `proccess.exit(0)` method to prevent SIGTERM being called twice

### Why did it change

- Due to SIGTERM erroring when trying to close the server the second time

![image](https://github.com/user-attachments/assets/fc86be7b-d64e-49b1-aebb-139b180521c1)


### Issue tracking

- [OJ-2871](https://govukverify.atlassian.net/browse/OJ-2871)

## Checklists

### Environment variables or secrets




[OJ-2871]: https://govukverify.atlassian.net/browse/OJ-2871?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ