### PR TITLE
OJ-3038: Change Postcode search to use the POST postcode-lookup endpoint

### DIFF
--- a/src/app/address/controllers/address/search.js
+++ b/src/app/address/controllers/address/search.js
@@ -44,17 +44,18 @@ class AddressSearchController extends BaseController {
           session_id: req.session.tokenId,
           "session-id": req.session.tokenId,
           ...createPersonalDataHeaders(
-            `${API.BASE_URL}${API.PATHS.POSTCODE_LOOKUP}/${postcode}`,
+            `${API.BASE_URL}${API.PATHS.POSTCODE_LOOKUP}`,
             req
           ),
         }
       : createPersonalDataHeaders(
-          `${API.BASE_URL}${API.PATHS.POSTCODE_LOOKUP}/${postcode}`,
+          `${API.BASE_URL}${API.PATHS.POSTCODE_LOOKUP}`,
           req
         ); // set the header to null should fail the req but pass the browser tests for now.
 
-    const addressResults = await req.axios.get(
-      `${API.PATHS.POSTCODE_LOOKUP}/${postcode}`,
+    const addressResults = await req.axios.post(
+      `${API.PATHS.POSTCODE_LOOKUP}`,
+      { postcode },
       {
         headers,
       }

--- a/src/app/address/controllers/address/search.test.js
+++ b/src/app/address/controllers/address/search.test.js
@@ -52,8 +52,11 @@ describe("Address Search controller", function () {
         "txma-audit-encoded": "dummy-txma-header",
         "x-forwarded-for": "127.0.0.1",
       };
-      expect(req.axios.get).to.have.been.calledWith(
-        `${POSTCODE_LOOKUP}/myPostcode`,
+      expect(req.axios.post).to.have.been.calledWith(
+        `${POSTCODE_LOOKUP}`,
+        {
+          postcode: "myPostcode",
+        },
         {
           headers,
         }
@@ -68,7 +71,7 @@ describe("Address Search controller", function () {
         prototypeSpy = sinon.stub(BaseController.prototype, "saveValues");
         BaseController.prototype.saveValues.callThrough();
 
-        req.axios.get = sinon.fake.returns(testData.apiResponse);
+        req.axios.post = sinon.fake.returns(testData.apiResponse);
 
         testPostcode = "myPostcode";
         req.body["addressSearch"] = testPostcode;
@@ -99,7 +102,7 @@ describe("Address Search controller", function () {
 
     describe("on api error", () => {
       beforeEach(async () => {
-        req.axios.get = sinon.fake.rejects(new Error("Error!"));
+        req.axios.post = sinon.fake.rejects(new Error("Error!"));
 
         testPostcode = "myPostcode";
         req.body["addressSearch"] = testPostcode;

--- a/test/mocks/mappings/addresses.json
+++ b/test/mocks/mappings/addresses.json
@@ -36,8 +36,15 @@
     {
       "scenarioName": "Compliance for addresses discussed at https://github.com/alphagov/digital-identity-architecture/blob/main/rfc/0020-address-structure.md",
       "request": {
-        "method": "GET",
-        "urlPathPattern": "/postcode-lookup/ZZ1%201ZZ",
+        "method": "POST",
+        "urlPathPattern": "/postcode-lookup",
+        "bodyPatterns": [
+          {
+            "equalToJson": {
+              "postcode": "ZZ1 1ZZ"
+            }
+          }
+        ],
         "headers": {
           "x-scenario-id": {
             "equalTo": "address-success"
@@ -121,8 +128,15 @@
       "requiredScenarioState": "AddressResponses",
       "newScenarioState": "AddressResponses",
       "request": {
-        "method": "GET",
-        "url": "/postcode-lookup/E1%208QS",
+        "method": "POST",
+        "url": "/postcode-lookup",
+        "bodyPatterns": [
+          {
+            "equalToJson": {
+              "postcode": "E1 8QS"
+            }
+          }
+        ],
         "headers": {
           "x-scenario-id": {
             "equalTo": "address-success"
@@ -160,8 +174,15 @@
       "requiredScenarioState": "Started",
       "newScenarioState": "AddressResponses",
       "request": {
-        "method": "GET",
-        "url": "/postcode-lookup/XXX_XX",
+        "method": "POST",
+        "url": "/postcode-lookup",
+        "bodyPatterns": [
+          {
+            "equalToJson": {
+              "postcode": "XXX_XX"
+            }
+          }
+        ],
         "headers": {
           "x-scenario-id": {
             "equalTo": "address-success",
@@ -185,8 +206,15 @@
       "requiredScenarioState": "AddressResponses",
       "newScenarioState": "AddressResponses",
       "request": {
-        "method": "GET",
-        "url": "/postcode-lookup/PR3VC0DE",
+        "method": "POST",
+        "url": "/postcode-lookup",
+        "bodyPatterns": [
+          {
+            "equalToJson": {
+              "postcode": "PR3VC0DE"
+            }
+          }
+        ],
         "headers": {
           "x-scenario-id": {
             "equalTo": "address-success"

--- a/test/mocks/mappings/authorization-error.json
+++ b/test/mocks/mappings/authorization-error.json
@@ -38,8 +38,15 @@
       "requiredScenarioState": "AddressResponses",
       "newScenarioState": "AddressResponses",
       "request": {
-        "method": "GET",
-        "url": "/postcode-lookup/E1%208QS",
+        "method": "POST",
+        "url": "/postcode-lookup",
+        "bodyPatterns": [
+          {
+            "equalToJson": {
+              "postcode": "E1 8QS"
+            }
+          }
+        ],
         "headers": {
           "x-scenario-id": {
             "equalTo": "address-authorization-error"
@@ -77,8 +84,15 @@
       "requiredScenarioState": "Started",
       "newScenarioState": "AddressResponses",
       "request": {
-        "method": "GET",
-        "url": "/postcode-lookup/XXX_XX",
+        "method": "POST",
+        "url": "/postcode-lookup",
+        "bodyPatterns": [
+          {
+            "equalToJson": {
+              "postcode": "XXX_XX"
+            }
+          }
+        ],
         "headers": {
           "x-scenario-id": {
             "equalTo": "address-authorization-error",
@@ -102,8 +116,15 @@
       "requiredScenarioState": "AddressResponses",
       "newScenarioState": "AddressResponses",
       "request": {
-        "method": "GET",
-        "url": "/postcode-lookup/PR3VC0DE",
+        "method": "POST",
+        "url": "/postcode-lookup",
+        "bodyPatterns": [
+          {
+            "equalToJson": {
+              "postcode": "PR3VC0DE"
+            }
+          }
+        ],
         "headers": {
           "x-scenario-id": {
             "equalTo": "address-authorization-error"

--- a/test/mocks/mappings/prepopulated-addresses.json
+++ b/test/mocks/mappings/prepopulated-addresses.json
@@ -96,8 +96,15 @@
       "requiredScenarioState": "AddressResponses",
       "newScenarioState": "AddressResponses",
       "request": {
-        "method": "GET",
-        "url": "/postcode-lookup/E1%208QS",
+        "method": "POST",
+        "url": "/postcode-lookup",
+        "bodyPatterns": [
+          {
+            "equalToJson": {
+              "postcode": "E1 8QS"
+            }
+          }
+        ],
         "headers": {
           "x-scenario-id": {
             "equalTo": "address-prepopulated"
@@ -135,8 +142,15 @@
       "requiredScenarioState": "Started",
       "newScenarioState": "AddressResponses",
       "request": {
-        "method": "GET",
-        "url": "/postcode-lookup/XXX_XX",
+        "method": "POST",
+        "url": "/postcode-lookup",
+        "bodyPatterns": [
+          {
+            "equalToJson": {
+              "postcode": "XXX_XX"
+            }
+          }
+        ],
         "headers": {
           "x-scenario-id": {
             "equalTo": "address-prepopulated",
@@ -160,8 +174,15 @@
       "requiredScenarioState": "AddressResponses",
       "newScenarioState": "AddressResponses",
       "request": {
-        "method": "GET",
-        "url": "/postcode-lookup/PR3VC0DE",
+        "method": "POST",
+        "url": "/postcode-lookup",
+        "bodyPatterns": [
+          {
+            "equalToJson": {
+              "postcode": "PR3VC0DE"
+            }
+          }
+        ],
         "headers": {
           "x-scenario-id": {
             "equalTo": "address-prepopulated"


### PR DESCRIPTION
The GET /postcode-lookup/{postcode} is being decommissioned (To prevent postcodes being logged). This changes the search controller to use the POST /postcode-lookup endpoint with the postcode sent in the request body.

Updated mocks to remove all GET /postcode-lookup/{postcode} mocks and replace the with POST /postcode-lookup

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

<!-- Describe the changes in detail - the "what"-->

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [OJ-XXXX](https://govukverify.atlassian.net/browse/OJ-XXXX)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->

- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
