### PR TITLE
OJ-2794: Add missing redirect error handling middleware

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -65,6 +65,9 @@ const helmetConfig = require("@govuk-one-login/di-ipv-cri-common-express/src/lib
 const {
   frontendVitalSignsInitFromApp,
 } = require("@govuk-one-login/frontend-vital-signs");
+const {
+  missingRedirectErrorHandler,
+} = require("./middleware/missingRedirectErrorHandler");
 
 const { app, router } = setup({
   config: { APP_ROOT: __dirname },
@@ -186,6 +189,7 @@ router.use("^/$", (req, res) => {
 });
 
 router.use(commonExpress.lib.errorHandling.redirectAsErrorToCallback);
+router.use(missingRedirectErrorHandler);
 
 /* Server configuration */
 const server = app.listen(PORT);

--- a/src/middleware/missingRedirectErrorHandler.js
+++ b/src/middleware/missingRedirectErrorHandler.js
@@ -1,0 +1,14 @@
+const { PACKAGE_NAME } = require("../lib/config");
+const logger = require("hmpo-logger").get(PACKAGE_NAME);
+
+module.exports = {
+  missingRedirectErrorHandler: async (err, req, res, next) => {
+    if (err.message === "Missing redirect_uri") {
+      logger.warn("Missing redirect_uri");
+      res.status(400);
+      res.render("errors/error");
+    } else {
+      next(err);
+    }
+  },
+};

--- a/src/middleware/missingRedirectErrorHandler.test.js
+++ b/src/middleware/missingRedirectErrorHandler.test.js
@@ -1,0 +1,38 @@
+const {
+  missingRedirectErrorHandler,
+} = require("./missingRedirectErrorHandler");
+
+describe("Missing Redirect Error Handler Middleware", () => {
+  let err, req, res, next;
+
+  beforeEach(() => {
+    const setup = setupDefaultMocks();
+    err = setup.err;
+    req = setup.req;
+    res = setup.res;
+    next = setup.next;
+  });
+
+  it("exports a function with length 4 - express identifies error handling middleware by its arguments length", async () => {
+    missingRedirectErrorHandler.should.be.a("function");
+    missingRedirectErrorHandler.length.should.equal(4);
+  });
+
+  it("should return 400 and render error page if error has the message Missing redirect_uri", async () => {
+    err.message = "Missing redirect_uri";
+    await missingRedirectErrorHandler(err, req, res, next);
+    expect(res.status).to.have.been.calledWith(400);
+    expect(res.render).to.have.been.calledWith("errors/error");
+  });
+
+  it("should call next if the error does not have the message Missing redirect_uri", async () => {
+    await missingRedirectErrorHandler(err, req, res, next);
+    expect(next).to.have.been.calledWith(err);
+  });
+
+  it("should call next if the error has a different message to Missing redirect_uri", async () => {
+    err.message = "I'm a different type of error";
+    await missingRedirectErrorHandler(err, req, res, next);
+    expect(next).to.have.been.calledWith(err);
+  });
+});

--- a/test/utils/mocha-helpers.js
+++ b/test/utils/mocha-helpers.js
@@ -50,11 +50,16 @@ global.setupDefaultMocks = () => {
     fields: {},
   });
 
-  const res = {};
+  const res = {
+    status: sinon.fake(),
+    render: sinon.fake(),
+  };
   const next = sinon.fake();
+  const err = sinon.stub();
   return {
     req,
     res,
     next,
+    err,
   };
 };


### PR DESCRIPTION
## Proposed changes

### What changed

Add middleware to handle `Missing redirect_uri` error. It will now Log the error as a warn, return a 400 and pass the user to the error page.

In the future we should lookup at how uses route through our app without oauth, and how we handle Axios errors.

### Why did it change

This error is causing a lot of noise in the logs making it difficult to debug other problems, and causing 500 errors for users which impacts our availability metrics.

### Issue tracking

- [OJ-2794](https://govukverify.atlassian.net/browse/OJ-2794)


[OJ-2794]: https://govukverify.atlassian.net/browse/OJ-2794?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ