### PR TITLE
IPS-1436 cloudfront migration for FMS

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -216,6 +216,9 @@ Resources:
           - Key: access_logs.s3.prefix
             Value: !Sub address-front-${Environment}
         - !Ref AWS::NoValue
+      Tags:
+        - Key: FMSRegionalPolicy
+          Value: false
 
   LoadBalancerListenerTargetGroupECS:
     Type: "AWS::ElasticLoadBalancingV2::TargetGroup"

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -191,7 +191,6 @@ Resources:
               - !Sub arn:aws:s3:::${AccessLogsBucket}/address-front-${Environment}/AWSLogs/${AWS::AccountId}/*
 
   CloudFrontWAFv2ACLAssociation:
-    Condition: IsNotDevelopment
     Type: AWS::WAFv2::WebACLAssociation
     Properties:
       ResourceArn: !Ref LoadBalancer

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -191,6 +191,7 @@ Resources:
               - !Sub arn:aws:s3:::${AccessLogsBucket}/address-front-${Environment}/AWSLogs/${AWS::AccountId}/*
 
   CloudFrontWAFv2ACLAssociation:
+    Condition: IsNotDevelopment
     Type: AWS::WAFv2::WebACLAssociation
     Properties:
       ResourceArn: !Ref LoadBalancer


### PR DESCRIPTION

## Proposed changes

### What changed

Load balancer upfates for the FMS firewall

### Why did it change

To enable central firewall management

### Issue tracking

- [IPS-1436](https://govukverify.atlassian.net/browse/IPS-1436)

## Checklists

### Environment variables or secrets

- [X] No environment variables or secrets were added or changed

### Other considerations

Application happening today

[IPS-1436]: https://govukverify.atlassian.net/browse/IPS-1436?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ