### PR TITLE
Fix: Address with previous is sending validFrom with null value

### DIFF
--- a/src/app/address/controllers/address/manual.js
+++ b/src/app/address/controllers/address/manual.js
@@ -107,7 +107,7 @@ class AddressController extends BaseController {
       streetName: addressStreetName,
       addressLocality,
       addressCountry: "GB",
-      validFrom,
+      ...(validFrom && { validFrom }),
     };
 
     const isChanged = this.checkForChanges(address, chosenAddress);


### PR DESCRIPTION
## Proposed changes

### What changed

Only sends `validFrom` in the body to `/address` if the value is not null (is truthy)

### Why did it change

I've turned on body validation on the `/address` endpoint to for https://github.com/govuk-one-login/ipv-cri-address-api/pull/1236 but the validation is failing when previous address are present with the `validFrom` null.
