### PR TITLE
OJ-3008: Use custom max length validator for UK address input fields

### DIFF
--- a/src/app/address/routes/sharedFields.js
+++ b/src/app/address/routes/sharedFields.js
@@ -48,9 +48,9 @@ module.exports = {
     type: "text",
     validate: [
       {
-        type: "maxlength",
-        fn: "maxlength",
-        arguments: [30],
+        type: "underMaxLength",
+        fn: underMaxLength,
+        arguments: 30,
       },
       {
         type: "alphaNumericWithSpecialChars",
@@ -62,9 +62,9 @@ module.exports = {
     type: "text",
     validate: [
       {
-        type: "maxlength",
-        fn: "maxlength",
-        arguments: [10],
+        type: "underMaxLength",
+        fn: underMaxLength,
+        arguments: 30,
       },
       {
         type: "alphaNumericWithSpecialChars",
@@ -76,9 +76,9 @@ module.exports = {
     type: "text",
     validate: [
       {
-        type: "maxlength",
-        fn: "maxlength",
-        arguments: [50],
+        type: "underMaxLength",
+        fn: underMaxLength,
+        arguments: 50,
       },
       {
         type: "alphaNumericWithSpecialChars",
@@ -90,9 +90,9 @@ module.exports = {
     type: "text",
     validate: [
       {
-        type: "maxlength",
-        fn: "maxlength",
-        arguments: [60],
+        type: "underMaxLength",
+        fn: underMaxLength,
+        arguments: 60,
       },
       {
         type: "alphaNumericWithSpecialChars",
@@ -107,9 +107,9 @@ module.exports = {
         type: "required",
       },
       {
-        type: "maxlength",
-        fn: "maxlength",
-        arguments: [60],
+        type: "underMaxLength",
+        fn: underMaxLength,
+        arguments: 60,
       },
       {
         type: "alphaNumericWithSpecialChars",

--- a/src/locales/cy/fields.yml
+++ b/src/locales/cy/fields.yml
@@ -15,29 +15,29 @@ addressFlatNumber:
   label: "Rif fflat (dewisol)"
   prefix: ""
   validation:
-    maxlength: "Gwiriwch eich bod wedi rhoi rhif eich fflat yn gywir"
+    underMaxLength: "Rhaid i'r rhif fflat fod yn 30 nod neu lai"
     alphaNumericWithSpecialChars: "Ni ddylai eich rif fflat gynnwys unrhyw nodau neu symbolau arbennig"
 addressHouseNumber:
   label: "Rhif tŷ"
   validation:
-    maxlength: "Gwiriwch eich bod wedi rhoi rhif eich tŷ yn yn gywir"
+    underMaxLength: "Rhaid i'r rhif tŷ fod yn 30 nod neu lai"
     alphaNumericWithSpecialChars: "Ni ddylai eich rhif tŷ gynnwys unrhyw nodau neu symbolau arbennig"
 addressHouseName:
   label: "Enw tŷ"
   validation:
-    maxlength: "Gwiriwch eich bod wedi rhoi enw eich tŷ yn yn gywir"
+    underMaxLength: "Rhaid i'r enw tŷ fod yn 50 nod neu lai"
     alphaNumericWithSpecialChars: "Ni ddylai eich enw tŷ gynnwys unrhyw nodau neu symbolau arbennig"
 addressStreetName:
   label: "Enw stryd (dewisol)"
   prefix: ""
   validation:
-    maxlength: "Gwiriwch eich bod wedi rhoi enw eich stryd yn yn gywir"
+    underMaxLength: "Rhaid i'r enw stryd fod yn 60 nod neu lai"
     alphaNumericWithSpecialChars: "Ni ddylai eich enw stryd gynnwys unrhyw nodau neu symbolau arbennig"
 addressLocality:
   label: "Tref neu ddinas"
   prefix: ""
   validation:
-    maxlength: "Gwiriwch eich bod wedi rhoi enw eich tref neu ddinas yn yn gywir"
+    underMaxLength: "Rhaid i'r dref neu'r ddinas fod yn 60 nod neu lai"
 
 nonUKAddressApartmentNumber:
   label: "Rhif fflat"

--- a/src/locales/en/fields.yml
+++ b/src/locales/en/fields.yml
@@ -17,33 +17,33 @@ addressFlatNumber:
   label: Flat number (optional)
   prefix: ""
   validation:
-    maxlength: Check you've entered your flat number correctly
+    underMaxLength: Flat number must be 30 characters or less
     alphaNumericWithSpecialChars: Your flat number should not include any special characters or symbols
 
 addressHouseNumber:
   label: House number
   validation:
-    maxlength: Check you've entered your house number correctly
+    underMaxLength: House number must be 30 characters or less
     alphaNumericWithSpecialChars: Your house number should not include any special characters or symbols
 
 addressHouseName:
   label: House name
   validation:
-    maxlength: Check you've entered your house name correctly
+    underMaxLength: House name must be 50 characters or less
     alphaNumericWithSpecialChars: Your house name should not include any special characters or symbols
 
 addressStreetName:
   label: Street name (optional)
   prefix: ""
   validation:
-    maxlength: Check you've entered your street name correctly
+    underMaxLength: Street name must be 60 characters or less
     alphaNumericWithSpecialChars: Your street name should not include any special characters or symbols
 
 addressLocality:
   label: Town or city
   prefix: ""
   validation:
-    maxlength: Check you've entered your town or city correctly
+    underMaxLength: Town or city must be 60 characters or less
 
 nonUKAddressApartmentNumber:
   label: Apartment number

--- a/test/browser/features/address-manual-max-length.feature
+++ b/test/browser/features/address-manual-max-length.feature
@@ -1,0 +1,26 @@
+@mock-api:address-success @success
+Feature: Happy Path - confirming manual address details
+  Confirming address details
+
+  Background:
+    Given Authenticalable Address Amy is using the system
+    And they have started the address journey
+    And they searched for their postcode "E1 8QS"
+    Then they should see the results page
+    When they have selected Cant find address
+    Then they should see the address page
+
+    Scenario: Entering address details fails validation when fields are too long
+      Given they are on the address page
+      When they add their flat number "1234567890123456789012345678901"
+      And they add their house number "1234567890123456789012345678901"
+      And they add their house name "123456789012345678901234567890123456789012345678901"
+      And they add their street "1234567890123456789012345678901234567890123456789012345678901"
+      And they add their city "1234567890123456789012345678901234567890123456789012345678901"
+      And they add their residency date with a "older" move year
+      And they continue to confirm address
+      Then they see an error summary with failed validation message: "Flat number must be 30 characters or less"
+      Then they see an error summary with failed validation message: "House number must be 30 characters or less"
+      Then they see an error summary with failed validation message: "House name must be 50 characters or less"
+      Then they see an error summary with failed validation message: "Street name must be 60 characters or less"
+      Then they see an error summary with failed validation message: "Town or city must be 60 characters or less"


### PR DESCRIPTION
## Proposed changes

### What changed

Use our own validator 'underMaxLength' that was added for the International address form, se we do validation on the field and not add the maxlength HTML property to it.

More info from int address PR: https://github.com/govuk-one-login/ipv-cri-address-front/pull/1076

### Why did it change

To enhance the user experience and ensure backend stability, we are implementing updates to the UK address form error messages to align with International address. This update will ensure a consistent, user-friendly approach to form validation while maintaining the reliability of backend systems.

### Issue tracking

- [OJ-3008](https://govukverify.atlassian.net/browse/OJ-3008)

## Screenshots

![image](https://github.com/user-attachments/assets/1c9a76c7-a447-43c4-a16b-9cdab249d552)
![image](https://github.com/user-attachments/assets/9378648a-288b-48a2-bf42-c6d9667d653a)


[OJ-3008]: https://govukverify.atlassian.net/browse/OJ-3008?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ