### PR TITLE
OJ-3115: Prevent address year 0000 being entered

### DIFF
--- a/src/app/address/routes/sharedFields.js
+++ b/src/app/address/routes/sharedFields.js
@@ -8,6 +8,7 @@ const {
 const {
   alphaNumericWithSpecialChars,
   isPreviousYear,
+  isNotZero,
 } = require("../validators/addressValidator");
 
 const { underMaxLength } = require("../validators/underMaxLengthValidator");
@@ -231,6 +232,10 @@ module.exports = {
         type: "isPreviousDate",
         fn: isPreviousYear,
       },
+      {
+        type: "isNotZero",
+        fn: isNotZero,
+      },
     ],
   },
   nonUKAddressYearFrom: {
@@ -245,6 +250,10 @@ module.exports = {
       {
         type: "isPreviousDate",
         fn: isPreviousYear,
+      },
+      {
+        type: "isNotZero",
+        fn: isNotZero,
       },
     ],
   },

--- a/src/app/address/validators/addressValidator.js
+++ b/src/app/address/validators/addressValidator.js
@@ -8,6 +8,9 @@ module.exports = {
   isPreviousYear: function (val) {
     return new Date(val).getFullYear() <= new Date().getFullYear();
   },
+  isNotZero: function (val) {
+    return val !== "0000";
+  },
   ukBuildingAddressEmptyValidator: function (houseNumber, houseName) {
     const trimOrDefaultToEmpty = (value) =>
       value != null ? String(value).trim() : "";

--- a/src/app/address/validators/addressValidator.test.js
+++ b/src/app/address/validators/addressValidator.test.js
@@ -2,6 +2,7 @@ const {
   alphaNumericWithSpecialChars,
   isPreviousYear,
   ukBuildingAddressEmptyValidator,
+  isNotZero,
 } = require("./addressValidator");
 
 const today = new Date();
@@ -18,7 +19,7 @@ const validYears = [
   "2021",
   "2010",
   "1970",
-  "0000",
+  "0001",
   String(today.getFullYear()),
 ];
 
@@ -52,6 +53,17 @@ describe("Address validator", () => {
     it("should fail with invalid dates", () => {
       const results = invalidFutureYears.map(isPreviousYear);
       results.forEach((val) => expect(val).to.equal(false));
+    });
+  });
+
+  describe("isNotZero", () => {
+    it("should pass with valid year", () => {
+      const results = validYears.map(isNotZero);
+      results.forEach((val) => expect(val).to.equal(true));
+    });
+
+    it("should fail with invalid dates", () => {
+      expect(isNotZero("0000")).to.equal(false);
     });
   });
 

--- a/src/locales/cy/fields.yml
+++ b/src/locales/cy/fields.yml
@@ -94,6 +94,7 @@ nonUKAddressYearFrom:
     default: "Rhowch y flwyddyn gan ddefnyddio 4 digid yn unig"
     required: "Rhowch y flwyddyn"
     isPreviousDate: "Rhaid i'r dyddiad y dechreuoch chi fyw yn y cyfeiriad hwn fod yn y gorffennol"
+    isNotZero: "Rhowch y flwyddyn"
 
 addressYearFrom:
   title: "Pryd wnaethoch ddechrau byw yn y cyfeiriad hwn?"
@@ -103,6 +104,7 @@ addressYearFrom:
     default: "Rhowch y flwyddyn gan ddefnyddio 4 digid yn unig"
     required: "Rhowch y flwyddyn"
     isPreviousDate: "Rhaid i'r dyddiad y dechreuoch chi fyw yn y cyfeiriad hwn fod yn y gorffennol"
+    isNotZero: "Rhowch y flwyddyn"
 addressResults:
   label: "Dewiswch eich cyfeiriad cartref presennol o'r rhestr"
   validation:

--- a/src/locales/en/fields.yml
+++ b/src/locales/en/fields.yml
@@ -100,6 +100,7 @@ addressYearFrom:
     default: Enter the year using only 4 digits
     required: Enter the year
     isPreviousDate: The date you started living at this address must be in the past
+    isNotZero: Enter the year
 
 nonUKAddressYearFrom:
   title: When did you start living at this address?
@@ -109,6 +110,7 @@ nonUKAddressYearFrom:
     default: Enter the year using only 4 digits
     required: Enter the year
     isPreviousDate: Enter a year that is not in the future
+    isNotZero: Enter the year
 
 addressResults:
   label: Choose your current home address from the list


### PR DESCRIPTION
## Proposed changes

### What changed

Added `isNotZero` validator to the year input fields. 

### Why did it change

Entering `0000` into the year field created a date 0000-01-01. The parsing of address in the Address lambda is unable to parse the year 0000 and throws a JSONProcessingException resulting in a 5XX error. (See linked tickets for details on the error).

This will catch the input in the FE and prevent it reaching the backend an users experience errors.

### Issue tracking

- [OJ-3115](https://govukverify.atlassian.net/browse/OJ-3115)

## Note

This is in draft as the error message needs confirming, and browser test adding once confirmed. 

## Screenshot

![image](https://github.com/user-attachments/assets/4486b471-28e1-401f-abf9-06d38059dc31)


[OJ-3115]: https://govukverify.atlassian.net/browse/OJ-3115?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ