### PR TITLE
OJ-3167: Fix keys for missing countries

### DIFF
--- a/src/app/address/data/countries.json
+++ b/src/app/address/data/countries.json
@@ -192,7 +192,7 @@
   },
   {
     "value": "CY",
-    "key": "countries.CU"
+    "key": "countries.CY"
   },
   {
     "value": "CZ",
@@ -576,7 +576,7 @@
   },
   {
     "value": "PA",
-    "key": "countries.PW"
+    "key": "countries.PA"
   },
   {
     "value": "PG",


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Fix translation keys for missing countries

### Why did it change

Copy and paste error meant that the keys for Cyprus and Panama were showing at Cuba and Palau

### Screenshots

Before
<img width="1119" alt="image" src="https://github.com/user-attachments/assets/e3b47586-0731-48e0-ba93-68bb0697d632" />

After
<img width="863" alt="image" src="https://github.com/user-attachments/assets/62098f45-069d-48e4-bdf7-3b5577e19926" />
<img width="920" alt="image" src="https://github.com/user-attachments/assets/fe93166d-9117-4158-aa08-28f2e463c22a" />


### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [OJ-3167](https://govukverify.atlassian.net/browse/OJ-3167)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->

- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[OJ-3167]: https://govukverify.atlassian.net/browse/OJ-3167?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ