### PR TITLE
OJ-3121: Use common-express overload-protection

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,12 +54,10 @@
     "hmpo-i18n": "7.0.0",
     "hmpo-logger": "8.0.0",
     "nunjucks": "3.2.4",
-    "overload-protection": "1.2.3",
     "wiremock": "3.10.0"
   },
   "devDependencies": {
     "@cucumber/cucumber": "11.0.1",
-    "@types/overload-protection": "1.2.4",
     "chai": "4.4.1",
     "chai-as-promised": "7.1.1",
     "eslint": "8.56.0",

--- a/src/app.js
+++ b/src/app.js
@@ -31,6 +31,7 @@ const {
   SESSION_SECRET,
   SESSION_TABLE_NAME,
   SESSION_TTL,
+  OVERLOAD_PROTECTION,
 } = require("./lib/config");
 
 const { setup } =
@@ -43,8 +44,6 @@ const loggerConfig = {
   appLevel: LOG_LEVEL,
   app: false,
 };
-
-const protect = require("overload-protection");
 
 const dynamodb = new DynamoDB({
   region: "eu-west-2",
@@ -118,20 +117,8 @@ const { app, router } = setup({
       ],
     });
     app.use(setHeaders);
-
-    app.use(
-      protect("express", {
-        production: process.env.NODE_ENV === "production",
-        clientRetrySecs: 1,
-        sampleInterval: 5,
-        maxEventLoopDelay: 400,
-        maxHeapUsedBytes: 0,
-        maxRssBytes: 0,
-        errorPropagationMode: false,
-        logging: "error",
-      })
-    );
   },
+  overloadProtection: OVERLOAD_PROTECTION,
   dev: true,
 });
 

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -37,4 +37,14 @@ module.exports = {
     SESSION_URL: process.env.REDIS_SESSION_URL,
     PORT: process.env.REDIS_PORT || 6379,
   },
+  OVERLOAD_PROTECTION: {
+    production: process.env.NODE_ENV === "production",
+    clientRetrySecs: 1,
+    sampleInterval: 5,
+    maxEventLoopDelay: 400,
+    maxHeapUsedBytes: 0,
+    maxRssBytes: 0,
+    errorPropagationMode: false,
+    logging: "error",
+  },
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1931,11 +1931,6 @@
   resolved "https://registry.yarnpkg.com/@types/normalize-package-data/-/normalize-package-data-2.4.4.tgz#56e2cc26c397c038fab0e3a917a12d5c5909e901"
   integrity sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==
 
-"@types/overload-protection@1.2.4":
-  version "1.2.4"
-  resolved "https://registry.yarnpkg.com/@types/overload-protection/-/overload-protection-1.2.4.tgz#d0ebacee6c95be3421ab252edbc2b801a74ee9b5"
-  integrity sha512-zbKBN5pZXwF4yiXUeF0Cng4Y+sqqTWVeyi++uR6Ycd8oThOGPBMEdHyX81Z1vU4wojh9+NDS0y6JX7nM6ylBCw==
-
 "@types/responselike@^1.0.0":
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/@types/responselike/-/responselike-1.0.3.tgz#cc29706f0a397cfe6df89debfe4bf5cea159db50"


### PR DESCRIPTION
## Proposed changes

### What changed

Removed existing overload-protection, replaced with common-express implementation.

### Why did it change

Remove custom logic. 

### Issue tracking

- [OJ-3121](https://govukverify.atlassian.net/browse/OJ-3121)

[OJ-3121]: https://govukverify.atlassian.net/browse/OJ-3121?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ