### PR TITLE
BAU: Upgrade github-actions to latest version

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Run pre-commit
-        uses: govuk-one-login/github-actions/code-quality/run-pre-commit@52a9e8e35980e6bcaf24d88180a61501e6f2605b
+        uses: govuk-one-login/github-actions/code-quality/run-pre-commit@c8eefadf581d2087ce2af48b7060c1329cfa5251
         with:
           node-version: 20
           install-dependencies: true
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Translation checks
-        uses: govuk-one-login/github-actions/env/run-script@145049ebd9a33e57da9a852847c4ee2c8970ea51
+        uses: govuk-one-login/github-actions/node/run-script@c8eefadf581d2087ce2af48b7060c1329cfa5251
         with:
           node-version: 20.x
           package-manager: yarn

--- a/.github/workflows/run-browser-tests.yml
+++ b/.github/workflows/run-browser-tests.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Run tests
-        uses: govuk-one-login/github-actions/env/run-script@145049ebd9a33e57da9a852847c4ee2c8970ea51
+        uses: govuk-one-login/github-actions/node/run-script@c8eefadf581d2087ce2af48b7060c1329cfa5251
         with:
           node-version: 20.x
           package-manager: yarn

--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Run tests
-        uses: govuk-one-login/github-actions/env/run-script@145049ebd9a33e57da9a852847c4ee2c8970ea51
+        uses: govuk-one-login/github-actions/node/run-script@c8eefadf581d2087ce2af48b7060c1329cfa5251
         with:
           node-version: 20.x
           package-manager: yarn

--- a/.github/workflows/scan-repo.yml
+++ b/.github/workflows/scan-repo.yml
@@ -30,7 +30,7 @@ jobs:
     if: ${{ success() || needs.coverage.result == 'skipped' }}
     steps:
       - name: Run SonarCloud scan
-        uses: govuk-one-login/github-actions/code-quality/sonarcloud@5480cced560e896dea12c47ea33e548a4d093e65
+        uses: govuk-one-login/github-actions/code-quality/sonarcloud@c8eefadf581d2087ce2af48b7060c1329cfa5251
         with:
           sonar-token: ${{ secrets.SONAR_TOKEN }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -44,6 +44,6 @@ jobs:
       security-events: write
     steps:
       - name: Run CodeQL scan
-        uses: govuk-one-login/github-actions/code-quality/codeql@145049ebd9a33e57da9a852847c4ee2c8970ea51
+        uses: govuk-one-login/github-actions/code-quality/codeql@c8eefadf581d2087ce2af48b7060c1329cfa5251
         with:
           languages: javascript


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Upgrade github-actions to latest version

### Why did it change

We are seeing a message saying we're using out of date actions, this was upgraded in the github-actions library [here](https://github.com/govuk-one-login/github-actions/blob/c8eefadf581d2087ce2af48b7060c1329cfa5251/code-quality/codeql/action.yml#L35)

<img width="1402" alt="image" src="https://github.com/user-attachments/assets/fc93d779-ecef-4502-8b4c-184253e68377" />

