### PR TITLE
OJ-3322: chore - bump frontend package to use latest changes for FEC

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@govuk-one-login/frontend-device-intelligence": "1.1.0",
     "@govuk-one-login/frontend-language-toggle": "1.1.0",
     "@govuk-one-login/frontend-passthrough-headers": "1.0.0",
+    "@govuk-one-login/frontend-ui": "1.3.12",
     "@govuk-one-login/frontend-vital-signs": "0.1.3",
     "accessible-autocomplete": "3.0.1",
     "axios": "1.11.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -973,9 +973,9 @@
     "@babel/types" "^7.28.0"
 
 "@babel/runtime@^7.23.2":
-  version "7.27.6"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.27.6.tgz#ec4070a04d76bae8ddbb10770ba55714a417b7c6"
-  integrity sha512-vbavdySgbTTrmFE+EsiqUTzlOr5bzlnJtUv9PynGCAKvfQqjIXbvFdumPM/GxMDfyuGMJaJAU6TO4zc1Jf1i8Q==
+  version "7.28.2"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.28.2.tgz#2ae5a9d51cc583bd1f5673b3bb70d6d819682473"
+  integrity sha512-KHp2IflsnGywDjBWDkR9iEqiWSpc8GIi0lgTT3mOElT0PP1tG26P4tmFI2YvAdzgq9RGyoHZQEIEdZy6Ec5xCA==
 
 "@babel/template@^7.27.2":
   version "7.27.2"
@@ -1204,9 +1204,9 @@
     pino "^8.20.0"
 
 "@govuk-one-login/frontend-ui@^1.2.0":
-  version "1.3.9"
-  resolved "https://registry.yarnpkg.com/@govuk-one-login/frontend-ui/-/frontend-ui-1.3.9.tgz#28a5e0615b8e77fa403364090e409d6eece4c449"
-  integrity sha512-PYrSRlqCauBAaObzeWchGT90B61pzt9Abjkx2tvdxZqzDBIfV1OPzHYS4Scd45ilVkY4O4CafRVqEPTJl0XCtw==
+  version "1.3.12"
+  resolved "https://registry.yarnpkg.com/@govuk-one-login/frontend-ui/-/frontend-ui-1.3.12.tgz#f859bfef55c4c22aed98c50fdb2d1ea686f8031c"
+  integrity sha512-EKf43hi61A5IhIlaFRO2gPlOTPkHvRDBLCiBGyWwppibDUvN+tYdvlhtn1UDsYZaHRXSl6cow/1ILE/DOwH3Vg==
   dependencies:
     js-yaml "^4.1.0"
     pino "8.20.0"
@@ -3823,7 +3823,7 @@ foreground-child@^3.1.0, foreground-child@^3.3.0, foreground-child@^3.3.1:
     cross-spawn "^7.0.6"
     signal-exit "^4.0.1"
 
-form-data@4.0.4, form-data@^4.0.4:
+form-data@^4.0.4:
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.4.tgz#784cdcce0669a9d68e94d11ac4eea98088edd2c4"
   integrity sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1160,7 +1160,7 @@
   resolved "https://registry.yarnpkg.com/@govuk-one-login/di-ipv-cri-common-express/-/di-ipv-cri-common-express-11.1.0.tgz#a506c905331c20d006ac886ddd0bc2dd410eb8e2"
   integrity sha512-mZFl69j8MkxlwOmwG4oCZ9dB2N3WOXCd7VgFTabp27z9aa9ITDAqs2a7q0d1bDSdPCv/ef0A8YV5nIz41cN7kg==
   dependencies:
-    "@govuk-one-login/frontend-ui" "^1.2.0"
+    "@govuk-one-login/frontend-ui" "1.3.12"
     async "^3.2.6"
     compression "^1.7.5"
     connect-redis "6.1.3"
@@ -1203,7 +1203,7 @@
     forwarded-parse "^2.1.2"
     pino "^8.20.0"
 
-"@govuk-one-login/frontend-ui@^1.2.0":
+"@govuk-one-login/frontend-ui@1.3.12":
   version "1.3.12"
   resolved "https://registry.yarnpkg.com/@govuk-one-login/frontend-ui/-/frontend-ui-1.3.12.tgz#f859bfef55c4c22aed98c50fdb2d1ea686f8031c"
   integrity sha512-EKf43hi61A5IhIlaFRO2gPlOTPkHvRDBLCiBGyWwppibDUvN+tYdvlhtn1UDsYZaHRXSl6cow/1ILE/DOwH3Vg==


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Updated `frontend-ui` package and when running yarn install updates a few dependencies too

Before using the stubs:

https://github.com/user-attachments/assets/b73f580c-0ad2-4efb-8700-3d66a97efb6c



After with the fix:

https://github.com/user-attachments/assets/56638a18-1b05-47ef-a119-cc13426322d5



### Why did it change

To enable branding.

### Issue tracking

- [OJ-3322](https://govukverify.atlassian.net/browse/OJ-3322)

## Checklists

### Environment variables or secrets


- [x] No environment variables or secrets were added or changed

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[OJ-3322]: https://govukverify.atlassian.net/browse/OJ-3322?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ