### PR TITLE
OJ-3312: Add date year validator less than 100 years

### DIFF
--- a/src/app/address/routes/sharedFields.js
+++ b/src/app/address/routes/sharedFields.js
@@ -8,6 +8,7 @@ const {
 const {
   alphaNumericWithSpecialChars,
   isPreviousYear,
+  isLessThanOneHundredYearsAgo,
 } = require("../validators/addressValidator");
 
 const { underMaxLength } = require("../validators/underMaxLengthValidator");
@@ -231,6 +232,10 @@ module.exports = {
         type: "isPreviousDate",
         fn: isPreviousYear,
       },
+      {
+        type: "isLessThanOneHundredYearsAgo",
+        fn: isLessThanOneHundredYearsAgo,
+      },
     ],
   },
   nonUKAddressYearFrom: {
@@ -245,6 +250,10 @@ module.exports = {
       {
         type: "isPreviousDate",
         fn: isPreviousYear,
+      },
+      {
+        type: "isLessThanOneHundredYearsAgo",
+        fn: isLessThanOneHundredYearsAgo,
       },
     ],
   },

--- a/src/app/address/validators/addressValidator.js
+++ b/src/app/address/validators/addressValidator.js
@@ -8,6 +8,9 @@ module.exports = {
   isPreviousYear: function (val) {
     return new Date(val).getFullYear() <= new Date().getFullYear();
   },
+  isLessThanOneHundredYearsAgo: function (val) {
+    return val > new Date().getFullYear() - 100;
+  },
   ukBuildingAddressEmptyValidator: function (houseNumber, houseName) {
     const trimOrDefaultToEmpty = (value) =>
       value != null ? String(value).trim() : "";

--- a/src/app/address/validators/addressValidator.test.js
+++ b/src/app/address/validators/addressValidator.test.js
@@ -1,6 +1,7 @@
 const {
   alphaNumericWithSpecialChars,
   isPreviousYear,
+  isLessThanOneHundredYearsAgo,
   ukBuildingAddressEmptyValidator,
 } = require("./addressValidator");
 
@@ -14,12 +15,14 @@ const validInput = [
   "ST. JOHN'S ROAD",
 ];
 
+const currentYear = today.getFullYear();
+
 const validYears = [
-  "2021",
-  "2010",
-  "1970",
-  "0000",
-  String(today.getFullYear()),
+  currentYear - 3,
+  currentYear - 15,
+  currentYear - 50,
+  currentYear - 99,
+  currentYear,
 ];
 
 const invalidInput = ["()%&^5$£@!|", "BadFlatNumber%"];
@@ -52,6 +55,23 @@ describe("Address validator", () => {
     it("should fail with invalid dates", () => {
       const results = invalidFutureYears.map(isPreviousYear);
       results.forEach((val) => expect(val).to.equal(false));
+    });
+  });
+
+  describe("isLessThanOneHundredYearsAgo", () => {
+    it("should pass with valid year", () => {
+      const results = validYears.map(isLessThanOneHundredYearsAgo);
+      results.forEach((val) => expect(val).to.equal(true));
+    });
+
+    it("should fail with date > 100 years", () => {
+      const invalidPastYears = [currentYear - 101, currentYear - 1000, 0];
+      const results = invalidPastYears.map(isLessThanOneHundredYearsAgo);
+      results.forEach((val) => expect(val).to.equal(false));
+    });
+
+    it("should fail with date 0000", () => {
+      expect(isLessThanOneHundredYearsAgo("0000")).to.equal(false);
     });
   });
 

--- a/src/locales/cy/fields.yml
+++ b/src/locales/cy/fields.yml
@@ -94,6 +94,7 @@ nonUKAddressYearFrom:
     default: "Rhowch y flwyddyn gan ddefnyddio 4 digid yn unig"
     required: "Rhowch y flwyddyn"
     isPreviousDate: "Rhaid i'r dyddiad y dechreuoch chi fyw yn y cyfeiriad hwn fod yn y gorffennol"
+    isLessThanOneHundredYearsAgo: "Rhowch flwyddyn sy'n llai na 100 mlynedd yn ôl"
 
 addressYearFrom:
   title: "Pryd wnaethoch ddechrau byw yn y cyfeiriad hwn?"
@@ -103,6 +104,7 @@ addressYearFrom:
     default: "Rhowch y flwyddyn gan ddefnyddio 4 digid yn unig"
     required: "Rhowch y flwyddyn"
     isPreviousDate: "Rhaid i'r dyddiad y dechreuoch chi fyw yn y cyfeiriad hwn fod yn y gorffennol"
+    isLessThanOneHundredYearsAgo: "Rhowch flwyddyn sy'n llai na 100 mlynedd yn ôl"
 addressResults:
   label: "Dewiswch eich cyfeiriad cartref presennol o'r rhestr"
   validation:

--- a/src/locales/en/fields.yml
+++ b/src/locales/en/fields.yml
@@ -100,6 +100,7 @@ addressYearFrom:
     default: Enter the year using only 4 digits
     required: Enter the year
     isPreviousDate: The date you started living at this address must be in the past
+    isLessThanOneHundredYearsAgo: Enter a year less than 100 years ago
 
 nonUKAddressYearFrom:
   title: When did you start living at this address?
@@ -109,6 +110,7 @@ nonUKAddressYearFrom:
     default: Enter the year using only 4 digits
     required: Enter the year
     isPreviousDate: Enter a year that is not in the future
+    isLessThanOneHundredYearsAgo: Enter a year less than 100 years ago
 
 addressResults:
   label: Choose your current home address from the list

--- a/yarn.lock
+++ b/yarn.lock
@@ -1217,6 +1217,13 @@
   dependencies:
     copy-webpack-plugin "^12.0.2"
 
+"@govuk-one-login/frontend-analytics@^4.0.1":
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/@govuk-one-login/frontend-analytics/-/frontend-analytics-4.0.1.tgz#2ede495f5fa2821566a00d2119ddf5bf6e57e296"
+  integrity sha512-BFbIu8Ujh4jdRQFwm77JteBs+x10ikyfmh1LZy1YVaiwlKY9k1GV8J/DDTIEbFdcOjUZK4RMSka/epK5G+mLtg==
+  dependencies:
+    loglevel "^1.9.2"
+
 "@govuk-one-login/frontend-device-intelligence@1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@govuk-one-login/frontend-device-intelligence/-/frontend-device-intelligence-1.1.0.tgz#46986297b4bc18331a520a7ca7750ec2696ff081"
@@ -1243,6 +1250,17 @@
     js-yaml "^4.1.0"
     pino "8.20.0"
   optionalDependencies:
+    hmpo-components "^7.1.0"
+
+"@govuk-one-login/frontend-ui@^1.2.0":
+  version "1.4.3"
+  resolved "https://registry.yarnpkg.com/@govuk-one-login/frontend-ui/-/frontend-ui-1.4.3.tgz#11d3aeebab26e0675ce93c3064f5e20c306d1c78"
+  integrity sha512-N7b2RtoHM8jR/v6wEVJoZ4RcBhLFDILUKJEDzqklrgfC0DwXnlVMu4fextGtyRmzXcWFm7+z4I3It8KYf9UzZA==
+  dependencies:
+    js-yaml "^4.1.0"
+    pino "8.20.0"
+  optionalDependencies:
+    "@govuk-one-login/frontend-analytics" "^4.0.1"
     hmpo-components "^7.1.0"
 
 "@govuk-one-login/frontend-vital-signs@0.1.3":
@@ -5028,6 +5046,11 @@ log-update@^4.0.0:
     cli-cursor "^3.1.0"
     slice-ansi "^4.0.0"
     wrap-ansi "^6.2.0"
+
+loglevel@^1.9.2:
+  version "1.9.2"
+  resolved "https://registry.yarnpkg.com/loglevel/-/loglevel-1.9.2.tgz#c2e028d6c757720107df4e64508530db6621ba08"
+  integrity sha512-HgMmCqIJSAKqo68l0rS2AanEWfkxaZ5wNiEFb5ggm08lDs9Xl2KxBlX3PTcaD2chBM1gXAYf491/M2Rv8Jwayg==
 
 loopbench@^1.2.0:
   version "1.2.0"


### PR DESCRIPTION
## Proposed changes

### What changed

Added `isLessThanOneHundredYearsAgo` validator to the date year input fields.

### Why did it change

Ensure the year entered for moving in to an address is realistic. 

### Issue tracking

- [OJ-3312](https://govukverify.atlassian.net/browse/OJ-3312)

