### PR TITLE
use stack name in AddressFrontSessionsTable name

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -387,9 +387,7 @@ Resources:
             - Name: EXTERNAL_WEBSITE_HOST
               Value: !GetAtt ApiGwHttpEndpoint.ApiEndpoint
             - Name: SESSION_TABLE_NAME
-              Value: !Sub
-                - "cri-address-front-sessions-${Environment}"
-                - Environment: !Ref Environment
+              Value: !Ref AddressFrontSessionsTable
             - Name: UA_CONTAINER_ID
               Value: !If [IsProduction, "GTM-TT5HDKV", "GTM-TK92W68"]
             - Name: GA4_CONTAINER_ID
@@ -895,7 +893,10 @@ Resources:
     Type: AWS::DynamoDB::Table
     Properties:
       # checkov:skip=CKV_AWS_28: Point in time recovery is not necessary for this table.
-      TableName: !Sub "cri-address-front-sessions-${Environment}"
+      TableName: !If
+        - IsNotDevelopment
+        - !Sub "cri-address-front-sessions-${Environment}"
+        - !Sub "${AWS::StackName}-cri-address-front-sessions-${Environment}"
       BillingMode: "PAY_PER_REQUEST"
       AttributeDefinitions:
         - AttributeName: "id"


### PR DESCRIPTION
## Proposed changes

### What changed
use stack name in AddressFrontSessionsTable name for dev environment.

### Why did it change
so that we can create multiple FE stacks without the table name conflicting as it will already exist for the main stack.

* New session table created and the old one has been deleted in dev
* FE still works via core stub

### Issue tracking
- [OJ-3424](https://govukverify.atlassian.net/browse/OJ-3424)


[OJ-3424]: https://govukverify.atlassian.net/browse/OJ-3424?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ