### PR TITLE
OJ-3337 - Use yarn to launch frontend host

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,9 @@ COPY src/ ./src
 COPY .yarn/ ./.yarn
 COPY .yarnrc.yml yarn.lock package.json ./
 
+ENV YARN_CACHE_FOLDER=/opt/.yarn-cache
+RUN mkdir $YARN_CACHE_FOLDER
+
 RUN <<COMMANDS
   yarn install --ignore-scripts --frozen-lockfile
   yarn build

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -5,6 +5,9 @@ WORKDIR /app
 COPY .yarn ./.yarn
 COPY .yarnrc.yml ./
 
+ENV YARN_CACHE_FOLDER=/opt/.yarn-cache
+RUN mkdir $YARN_CACHE_FOLDER
+
 RUN [ "yarn", "set", "version", "1.22.17" ]
 
 COPY /src ./src


### PR DESCRIPTION
## Proposed changes

### What changed

- Updated Dockerfile so the frontend is launched with `tini -- yarn start` instead of `tini npm start yarn start`
- Overrode yarn's cache folder so it doesn't try and use `/root` for caching
  - This was causing `yarn start` to fail when we apply a readonly root filesystem

### Why did it change

- We use `yarn` as our package manager in the address frontend, so it makes sense to use it to execute the `start` script too
- Even in dev, which uses `yarn start`, we saw problems caused by yarn attempting to use `/root` for caching.
  - The error messages suggest that we provide a writable directory with the [YARN_CACHE_FOLDER](https://classic.yarnpkg.com/lang/en/docs/cli/cache/#toc-change-the-cache-path-for-yarn) environment variable. This solution was also discussed [here](https://github.com/yarnpkg/yarn/issues/6363).

### Issue tracking

- OJ-3337

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [x] No environment variables or secrets were added or changed

### Other considerations

- [x] Update [README](./blob/main/README.md) with any new instructions or tasks
