### PR TITLE
OJ-3337: Explicitly provide yarn cache folder argument

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,7 @@ COPY src/ ./src
 COPY .yarn/ ./.yarn
 COPY .yarnrc.yml yarn.lock package.json ./
 
-ENV YARN_CACHE_FOLDER=/opt/.yarn-cache
-RUN mkdir -p $YARN_CACHE_FOLDER
+RUN mkdir -p /opt/.yarn-cache
 
 RUN <<COMMANDS
   yarn install --ignore-scripts --frozen-lockfile
@@ -36,4 +35,6 @@ EXPOSE $PORT
 HEALTHCHECK --interval=10s --timeout=2s --start-period=5s --retries=3 \
   CMD curl -f http://localhost:$PORT/healthcheck || exit 1
 
-ENTRYPOINT ["sh", "-c", "export DT_HOST_ID=ADDRESS-CRI-FRONT-$RANDOM && tini yarn start"]
+ENTRYPOINT ["tini", "--"]
+
+CMD ["sh", "-c", "DT_HOST_ID=ADDRESS-CRI-FRONT-$RANDOM yarn start --cache-folder /opt/.yarn-cache"]

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -5,8 +5,7 @@ WORKDIR /app
 COPY .yarn ./.yarn
 COPY .yarnrc.yml ./
 
-ENV YARN_CACHE_FOLDER=/opt/.yarn-cache
-RUN mkdir -p $YARN_CACHE_FOLDER
+RUN mkdir -p /opt/.yarn-cache
 
 RUN [ "yarn", "set", "version", "1.22.17" ]
 
@@ -50,4 +49,4 @@ HEALTHCHECK --interval=10s --timeout=2s --start-period=5s --retries=3 \
 
 ENTRYPOINT ["tini", "--"]
 
-CMD ["yarn", "start"]
+CMD ["yarn", "start", "--cache-folder", "/opt/.yarn-cache"]


### PR DESCRIPTION
## Proposed changes

### What changed

- Pass yarn cache folder explicitly

### Why did it change

We want to be sure that yarn is receiving the cache folder before we start troubleshooting something else

### Issue tracking

- [OJ-3337](https://govukverify.atlassian.net/browse/OJ-3337)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [x] No environment variables or secrets were added or changed

### Other considerations

- [x] Update [README](./blob/main/README.md) with any new instructions or tasks


[OJ-3337]: https://govukverify.atlassian.net/browse/OJ-3337?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ