### PR TITLE
OJ-3337: Set yarn cache folder in runner, not builder

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,6 @@ COPY src/ ./src
 COPY .yarn/ ./.yarn
 COPY .yarnrc.yml yarn.lock package.json ./
 
-RUN mkdir -p /opt/.yarn-cache
-
 RUN <<COMMANDS
   yarn install --ignore-scripts --frozen-lockfile
   yarn build
@@ -18,6 +16,10 @@ COMMANDS
 
 FROM node:20.11.1-alpine3.19@${NODE_SHA} AS runner
 RUN apk --no-cache upgrade && apk add --no-cache tini curl
+
+ENV YARN_CACHE_FOLDER=/opt/.yarn-cache
+RUN mkdir -p $YARN_CACHE_FOLDER
+
 WORKDIR /app
 
 COPY --from=builder /app/package.json /app/yarn.lock ./

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -5,8 +5,6 @@ WORKDIR /app
 COPY .yarn ./.yarn
 COPY .yarnrc.yml ./
 
-RUN mkdir -p /opt/.yarn-cache
-
 RUN [ "yarn", "set", "version", "1.22.17" ]
 
 COPY /src ./src
@@ -25,6 +23,9 @@ FROM --platform="linux/arm64" arm64v8/node@sha256:56e8282f4392fb96c877babc93b382
 RUN apt-get update \
   && apt-get install -y --no-install-recommends curl tini \
   && rm -rf /var/lib/apt/lists/*
+
+ENV YARN_CACHE_FOLDER=/opt/.yarn-cache
+RUN mkdir -p $YARN_CACHE_FOLDER
 
 RUN [ "yarn", "set", "version", "1.22.17" ]
 


### PR DESCRIPTION
## Proposed changes

### What changed

- Correct the location of the yarn cache folder in the Dockerfile

### Why did it change

Previously, the directory was being created and the env var set in the builder, which meant the change could never affect the runtime.

### Issue tracking

- [OJ-3337](https://govukverify.atlassian.net/browse/OJ-3337)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [x] No environment variables or secrets were added or changed

### Other considerations

- [x] Update [README](./blob/main/README.md) with any new instructions or tasks


[OJ-3337]: https://govukverify.atlassian.net/browse/OJ-3337?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ