### PR TITLE
OJ-3337: Invoke node directly instead of using yarn

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,9 +17,6 @@ COMMANDS
 FROM node:20.11.1-alpine3.19@${NODE_SHA} AS runner
 RUN apk --no-cache upgrade && apk add --no-cache tini curl
 
-ENV YARN_CACHE_FOLDER=/opt/.yarn-cache
-RUN mkdir -p $YARN_CACHE_FOLDER
-
 WORKDIR /app
 
 COPY --from=builder /app/package.json /app/yarn.lock ./
@@ -39,4 +36,4 @@ HEALTHCHECK --interval=10s --timeout=2s --start-period=5s --retries=3 \
 
 ENTRYPOINT ["tini", "--"]
 
-CMD ["sh", "-c", "DT_HOST_ID=ADDRESS-CRI-FRONT-$RANDOM yarn start --cache-folder /opt/.yarn-cache"]
+CMD ["sh", "-c", "DT_HOST_ID=ADDRESS-CRI-FRONT-$RANDOM node app.js"]

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -24,9 +24,6 @@ RUN apt-get update \
   && apt-get install -y --no-install-recommends curl tini \
   && rm -rf /var/lib/apt/lists/*
 
-ENV YARN_CACHE_FOLDER=/opt/.yarn-cache
-RUN mkdir -p $YARN_CACHE_FOLDER
-
 RUN [ "yarn", "set", "version", "1.22.17" ]
 
 WORKDIR /app
@@ -50,4 +47,4 @@ HEALTHCHECK --interval=10s --timeout=2s --start-period=5s --retries=3 \
 
 ENTRYPOINT ["tini", "--"]
 
-CMD ["yarn", "start", "--cache-folder", "/opt/.yarn-cache"]
+CMD ["node", "app.js"]


### PR DESCRIPTION
## Proposed changes

### What changed

- Changed Dockerfile to execute `node app.js` rather than using `yarn start` or `npm start` to trigger it

### Why did it change

- We do not use npm in this repository, and yarn does not like launching with a read-only file system - even if all it's doing is triggering a script in package.json

### Issue tracking

- [OJ-3337](https://govukverify.atlassian.net/browse/OJ-3337)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [x] No environment variables or secrets were added or changed

### Other considerations

- [x] Update [README](./blob/main/README.md) with any new instructions or tasks


[OJ-3337]: https://govukverify.atlassian.net/browse/OJ-3337?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ