### PR TITLE
OJ-3337: Resolve typo in file path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,4 +36,4 @@ HEALTHCHECK --interval=10s --timeout=2s --start-period=5s --retries=3 \
 
 ENTRYPOINT ["tini", "--"]
 
-CMD ["sh", "-c", "DT_HOST_ID=ADDRESS-CRI-FRONT-$RANDOM node app.js"]
+CMD ["sh", "-c", "DT_HOST_ID=ADDRESS-CRI-FRONT-$RANDOM node src/app.js"]

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -47,4 +47,4 @@ HEALTHCHECK --interval=10s --timeout=2s --start-period=5s --retries=3 \
 
 ENTRYPOINT ["tini", "--"]
 
-CMD ["node", "app.js"]
+CMD ["node", "src/app.js"]


### PR DESCRIPTION
## Proposed changes

### What changed

- Change `node app.js` to `node src/app.js` to correctly imitate the `start` script in package.json

### Why did it change

`app.js` is not in the root of the repository.

### Issue tracking

- [OJ-3337](https://govukverify.atlassian.net/browse/OJ-3337)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [x] No environment variables or secrets were added or changed

### Other considerations

- [x] Update [README](./blob/main/README.md) with any new instructions or tasks


[OJ-3337]: https://govukverify.atlassian.net/browse/OJ-3337?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ