### PR TITLE
OJ-3444: Added custom policy for inclusion in custom-managed policy

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -670,6 +670,12 @@ Resources:
     Properties:
       Name: !Sub address-front-${Environment}
       ProtocolType: HTTP
+      Tags:
+        FMSRegionalPolicy: false
+        CustomPolicy: !If
+          - IsProductionOrIntegration
+          - "true"
+          - !Ref AWS::NoValue
 
   ApiGwHttpEndpointIntegration:
     Type: "AWS::ApiGatewayV2::Integration"
@@ -714,6 +720,12 @@ Resources:
           "responseLength":"$context.responseLength",
           "responseLatency":"$context.responseLatency"
           }
+      Tags:
+        FMSRegionalPolicy: false
+        CustomPolicy: !If
+          - IsProductionOrIntegration
+          - "true"
+          - !Ref AWS::NoValue
 
   APIGWAccessLogsGroup:
     Type: AWS::Logs::LogGroup

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -47,6 +47,7 @@ Conditions:
   IsNotDevelopment: !Not
     - !Equals [!Ref Environment, dev]
   IsProduction: !Equals [!Ref Environment, production]
+
   IsProductionOrIntegration: !Or
     - !Equals [!Ref Environment, production]
     - !Equals [!Ref Environment, integration]
@@ -252,6 +253,11 @@ Resources:
       Tags:
         - Key: FMSRegionalPolicy
           Value: false
+        - !If
+          - IsProductionOrIntegration
+          - Key: CustomPolicy
+            Value: "true"
+          - !Ref AWS::NoValue
 
   LoadBalancerListenerTargetGroupECS:
     Type: "AWS::ElasticLoadBalancingV2::TargetGroup"


### PR DESCRIPTION
## Proposed changes

As part of transitioning FMS WAF rule enforcement from COUNT to BLOCK, Security have set up custom policies for us to apply to our resources in scope. In COUNT mode FMS merely logs the rule violations, in BLOCK mode violating requests are actively blocked. 

The tags to implement this should only apply (conditionally) to resources deployed to dev, build and staging accounts. The tags must not apply to int and prod (there is a follow-up ticket for this:

### What changed

Apply tagging conditional to meet the above requirement

### Why did it change

**Tags On Load Balancer**
<img width="1109" height="659" alt="image" src="https://github.com/user-attachments/assets/05383ffc-a4f7-437d-88d0-132d4eb9e415" />

**Tags On ApiGateway**
<img width="632" height="728" alt="image" src="https://github.com/user-attachments/assets/4b3be28d-0c1d-400d-ad01-4d05fce47766" />


Part of transitioning FMS WAF rule enforcement

### Issue tracking

- [OJ-3444](https://govukverify.atlassian.net/browse/OJ-3444)

[OJ-3444]: https://govukverify.atlassian.net/browse/OJ-3444?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ