### PR TITLE
OJ-3642: Enable pino logger in lower environments

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -78,6 +78,7 @@ Mappings:
       deviceIntelligenceEnabled: true
       may2025RebrandEnabled: true
       logLevel: "info"
+      pinoLoggerEnabled: "true"
     build:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
       minECSCount: 6
@@ -85,6 +86,7 @@ Mappings:
       deviceIntelligenceEnabled: true
       may2025RebrandEnabled: true
       logLevel: "info"
+      pinoLoggerEnabled: "true"
     staging:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
       minECSCount: 2
@@ -92,6 +94,7 @@ Mappings:
       deviceIntelligenceEnabled: true
       may2025RebrandEnabled: true
       logLevel: "warn"
+      pinoLoggerEnabled: "false"
     integration:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
       minECSCount: 2
@@ -99,6 +102,7 @@ Mappings:
       deviceIntelligenceEnabled: true
       may2025RebrandEnabled: true
       logLevel: "warn"
+      pinoLoggerEnabled: "false"
     production:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceProductionVariables
       minECSCount: 6
@@ -106,6 +110,7 @@ Mappings:
       deviceIntelligenceEnabled: true
       may2025RebrandEnabled: true
       logLevel: "warn"
+      pinoLoggerEnabled: "false"
   # see https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-access-logs.html
   ElasticLoadBalancerAccountIds:
     eu-west-2:
@@ -458,6 +463,13 @@ Resources:
                   EnvironmentConfiguration,
                   !Ref Environment,
                   logLevel,
+                ]
+            - Name: USE_PINO_LOGGER
+              Value:
+                !FindInMap [
+                  EnvironmentConfiguration,
+                  !Ref Environment,
+                  pinoLoggerEnabled,
                 ]
           Secrets:
             - Name: DT_TENANT

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-dynamodb": "3.1005.0",
-        "@govuk-one-login/di-ipv-cri-common-express": "13.1.0",
+        "@govuk-one-login/di-ipv-cri-common-express": "13.2.0",
         "@govuk-one-login/frontend-analytics": "4.0.5",
         "@govuk-one-login/frontend-device-intelligence": "1.1.0",
         "@govuk-one-login/frontend-language-toggle": "1.1.0",
@@ -1361,9 +1361,9 @@
       }
     },
     "node_modules/@govuk-one-login/di-ipv-cri-common-express": {
-      "version": "13.1.0",
-      "resolved": "https://registry.npmjs.org/@govuk-one-login/di-ipv-cri-common-express/-/di-ipv-cri-common-express-13.1.0.tgz",
-      "integrity": "sha512-T0HN6Us0PLpSts6ENY6pun4w0jxYqed9jw3pcWrgvRRYappMETPHOTpbPl9in87yZTYqXipaM3AR/UTuFlkkiA==",
+      "version": "13.2.0",
+      "resolved": "https://registry.npmjs.org/@govuk-one-login/di-ipv-cri-common-express/-/di-ipv-cri-common-express-13.2.0.tgz",
+      "integrity": "sha512-7TAUrP6FeQYi1xxuIhQJrSlfbN7dr1XOjESMp8CPyde+ftaY3PaRMCe+qDUx7P4+YrX3+YHUeEo75/AV3HDZ5g==",
       "license": "MIT",
       "dependencies": {
         "@govuk-one-login/frontend-ui": "5.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4886,15 +4886,16 @@
       "license": "ISC"
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",
           "url": "https://github.com/sponsors/RubenVerborgh"
         }
       ],
+      "license": "MIT",
       "engines": {
         "node": ">=4.0"
       },
@@ -10363,10 +10364,11 @@
       "dev": true
     },
     "node_modules/yaml": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
-      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
       "dev": true,
+      "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"
       },

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-dynamodb": "3.1005.0",
-    "@govuk-one-login/di-ipv-cri-common-express": "13.1.0",
+    "@govuk-one-login/di-ipv-cri-common-express": "13.2.0",
     "@govuk-one-login/frontend-analytics": "4.0.5",
     "@govuk-one-login/frontend-device-intelligence": "1.1.0",
     "@govuk-one-login/frontend-language-toggle": "1.1.0",


### PR DESCRIPTION
## Proposed changes

### What changed

- Enabled pino logger in dev/build
- Ran npm audit fix

### Why did it change

- We are moving away from hmpo-logger

### Issue tracking

- OJ-3642

## Checklists

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

### Other considerations

- [x] Update [README](./blob/main/README.md) with any new instructions or tasks
