### PR TITLE
chore: bump axios to 1.16.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@govuk-one-login/frontend-ui": "5.0.0",
         "@govuk-one-login/frontend-vital-signs": "0.1.3",
         "accessible-autocomplete": "3.0.1",
-        "axios": "1.15.0",
+        "axios": "1.16.0",
         "connect-dynamodb": "^3.0.3",
         "copyfiles": "2.4.1",
         "dotenv": "16.4.5",
@@ -3415,12 +3415,11 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
-      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
-      "license": "MIT",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.0.tgz",
+      "integrity": "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==",
       "dependencies": {
-        "follow-redirects": "^1.15.11",
+        "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
         "proxy-from-env": "^2.1.0"
       }
@@ -7401,11 +7400,10 @@
       }
     },
     "node_modules/mocha/node_modules/brace-expansion": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
-      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
@@ -10955,7 +10953,7 @@
         "@aws-sdk/credential-providers": "3.1005.0",
         "@cucumber/cucumber": "12.8.2",
         "aws4-axios": "3.4.0",
-        "axios": "1.15.0",
+        "axios": "1.16.0",
         "chai": "4.4.1",
         "dotenv": "16.4.5",
         "playwright": "1.55.1"

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@govuk-one-login/frontend-ui": "5.0.0",
     "@govuk-one-login/frontend-vital-signs": "0.1.3",
     "accessible-autocomplete": "3.0.1",
-    "axios": "1.15.0",
+    "axios": "1.16.0",
     "connect-dynamodb": "^3.0.3",
     "copyfiles": "2.4.1",
     "dotenv": "16.4.5",

--- a/test/browser/package.json
+++ b/test/browser/package.json
@@ -13,7 +13,7 @@
     "@aws-sdk/credential-providers": "3.1005.0",
     "@cucumber/cucumber": "12.8.2",
     "aws4-axios": "3.4.0",
-    "axios": "1.15.0",
+    "axios": "1.16.0",
     "chai": "4.4.1",
     "dotenv": "16.4.5",
     "playwright": "1.55.1"


### PR DESCRIPTION
## Proposed changes

### What changed
Bumped axios as flagged by npm audit

### Issue tracking
- [OJ-3678](https://govukverify.atlassian.net/browse/OJ-3678)


[OJ-3678]: https://govukverify.atlassian.net/browse/OJ-3678?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ