### PR TITLE
chore: bump common-express to 14.0.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       ],
       "dependencies": {
         "@aws-sdk/client-dynamodb": "3.1005.0",
-        "@govuk-one-login/di-ipv-cri-common-express": "14.0.0",
+        "@govuk-one-login/di-ipv-cri-common-express": "14.0.3",
         "@govuk-one-login/frontend-analytics": "4.0.5",
         "@govuk-one-login/frontend-device-intelligence": "1.1.0",
         "@govuk-one-login/frontend-language-toggle": "1.1.0",
@@ -1695,9 +1695,9 @@
       }
     },
     "node_modules/@govuk-one-login/di-ipv-cri-common-express": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/@govuk-one-login/di-ipv-cri-common-express/-/di-ipv-cri-common-express-14.0.0.tgz",
-      "integrity": "sha512-VUx1r9UsjctQ9+z0fnSwmjOScZDyzUktbbZby2J2mVPA9/+ezsRiO06xJLAGY8UALXMdtHJGB+mJWPN9O18qmg==",
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/@govuk-one-login/di-ipv-cri-common-express/-/di-ipv-cri-common-express-14.0.3.tgz",
+      "integrity": "sha512-izV2t6iBMESkGpnw4OAxna2OnHS/uypzNSTTxEERwvl2wSUbyfgbxme9N9bFEpRt4HU/uWAktthVwDi7336Eag==",
       "license": "MIT",
       "dependencies": {
         "@govuk-one-login/frontend-ui": "5.0.0",
@@ -1719,7 +1719,6 @@
         "i18next-fs-backend": "2.6.5",
         "i18next-http-middleware": "3.9.6",
         "lodash.differencewith": "4.5.0",
-        "lodash.frompairs": "4.0.1",
         "nocache": "3.0.4",
         "on-finished": "2.4.1",
         "overload-protection": "1.2.3",
@@ -7077,11 +7076,6 @@
       "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
       "integrity": "sha512-uHaJFihxmJcEX3kT4I23ABqKKalJ/zDrDg0lsFtc1h+3uw49SIJ5beyhx5ExVRti3AvKoOJngIj7xz3oylPdWQ==",
       "dev": true
-    },
-    "node_modules/lodash.frompairs": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/lodash.frompairs/-/lodash.frompairs-4.0.1.tgz",
-      "integrity": "sha512-dvqe2I+cO5MzXCMhUnfYFa9MD+/760yx2aTAN1lqEcEkf896TxgrX373igVdqSJj6tQd0jnSLE1UMuKufqqxFw=="
     },
     "node_modules/lodash.kebabcase": {
       "version": "4.1.1",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-dynamodb": "3.1005.0",
-    "@govuk-one-login/di-ipv-cri-common-express": "14.0.0",
+    "@govuk-one-login/di-ipv-cri-common-express": "14.0.3",
     "@govuk-one-login/frontend-analytics": "4.0.5",
     "@govuk-one-login/frontend-device-intelligence": "1.1.0",
     "@govuk-one-login/frontend-language-toggle": "1.1.0",


### PR DESCRIPTION
## Proposed changes

### What changed
Bump common-express to 14.0.3

### Why did it change
It contains vulnerability fixes

### Issue tracking
- [OJ-3678](https://govukverify.atlassian.net/browse/OJ-3678)

[OJ-3678]: https://govukverify.atlassian.net/browse/OJ-3678?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ