### PR TITLE
IPS-2290 set minECSCount to 3 in prod as 6 is overprovisioned

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -116,7 +116,7 @@ Mappings:
       pinoLoggerEnabled: "false"
     production:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceProductionVariables
-      minECSCount: 6
+      minECSCount: 3
       maxECSCount: 60
       deviceIntelligenceEnabled: true
       may2025RebrandEnabled: true


### PR DESCRIPTION
## Proposed changes

### What changed

set minECSCount to 3 in prod as 6 is overprovisioned

Following performance tests, 3 instances is enough to handle traffic in production hence reducing the amount to save costs. 

### Why did it change

Linked PR - https://github.com/govuk-one-login/ipv-cri-address-front/pull/1378
6 instances are too many for the amount of traffic in Orange
We have scaling policies that will be triggered when there is a spike in traffic.

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [IPS-2290](https://govukverify.atlassian.net/browse/IPS-2290)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->

- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
