### PR TITLE
REX-1073 set min ecs count to 2 in build

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -98,7 +98,7 @@ Mappings:
       logLevel: "info"
     build:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
-      minECSCount: 3
+      minECSCount: 2
       maxECSCount: 60
       logLevel: "info"
     staging:


### PR DESCRIPTION
## Proposed changes

### What changed

Set min ecs count in build to 2.

### Why did it change

We want to test the resiliency of our system with 2 instances in 2 AZs.

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [REX-1073](https://govukverify.atlassian.net/browse/REX-1073)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->

- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[REX-1073]: https://govukverify.atlassian.net/browse/REX-1073?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ