### PR TITLE
OJ-3718: Only validate the address is different if on the previous flow

### DIFF
--- a/src/app/address/controllers/address/results.js
+++ b/src/app/address/controllers/address/results.js
@@ -26,7 +26,7 @@ export class AddressResultsController extends FormWizard.Controller {
   validateFields(req, res, callback) {
     const checkAddress = req.journeyModel.get("currentAddress");
     // only need to validate the address when there is another address already.
-    if (checkAddress) {
+    if (checkAddress && req.originalUrl.startsWith("/previous")) {
       const formFields = req.form.options.fields;
       const selectedAddress = req.form.values.addressResults;
       const searchResults = req.sessionModel.get("searchResults");

--- a/src/app/address/controllers/address/results.test.js
+++ b/src/app/address/controllers/address/results.test.js
@@ -120,6 +120,41 @@ describe("Address result controller", () => {
     });
   });
 
+  describe("#validateFields", () => {
+    beforeEach(() => {
+      req.form.options.fields.addressResults = {
+        validate: [],
+      };
+    });
+
+    it("Should add the addressSelectorValidator", async () => {
+      req.originalUrl = "/previous/results";
+      req.journeyModel.get = vi.fn().mockReturnValue(formattedAddresses[1]);
+      req.sessionModel.get = vi.fn().mockReturnValue(formattedAddresses);
+
+      addressResult.validateFields(req, res, next);
+
+      expect(req.form.options.fields.addressResults.validate).toHaveLength(1);
+    });
+
+    it("should not add the addressSelectorValidator when not previous flow", async () => {
+      req.originalUrl = "/results";
+      req.journeyModel.get = vi.fn().mockReturnValue(formattedAddresses[1]);
+
+      addressResult.validateFields(req, res, next);
+
+      expect(req.form.options.fields.addressResults.validate).toHaveLength(0);
+    });
+
+    it("Should not add the addressSelectorValidator when no current address", async () => {
+      req.originalUrl = "/previous/results";
+
+      addressResult.validateFields(req, res, next);
+
+      expect(req.form.options.fields.addressResults.validate).toHaveLength(0);
+    });
+  });
+
   describe("#saveValues", () => {
     it("Should set the chosen address in the session", async () => {
       const expectedResponse = formattedAddresses[1];

--- a/test/browser/features/address-results.feature
+++ b/test/browser/features/address-results.feature
@@ -12,3 +12,11 @@ Feature: Happy Path - confirming preselected address details and date invalidati
       Given they have selected an address "default"
       Then they should see the results page
       And they should see an error message on the results page "Choose an address"
+
+    Scenario: Should not show the validation message when pressing back and selecting the same address
+      Given they have selected an address ""
+      And they should see the address page
+      And they click back from the address page
+      And they should see the results page
+      When they have selected an address ""
+      Then they should see the address page

--- a/test/browser/pages/address.js
+++ b/test/browser/pages/address.js
@@ -29,6 +29,11 @@ export class AddressPage {
 
     return this.paths.findIndex((val) => val === pathname) !== -1;
   }
+
+  async clickBackOnPage() {
+    await this.page.click('[id="back"]');
+  }
+
   async addHouseNumber(value = "1A") {
     await this.page.fill("#addressHouseNumber", value);
   }

--- a/test/browser/step_definitions/address.js
+++ b/test/browser/step_definitions/address.js
@@ -17,6 +17,11 @@ Then(/they should see the address page$/, async function () {
   assert.strictEqual(addressPage.isCurrentPage(), true);
 });
 
+Then("they click back from the address page", async function () {
+  const addressPage = new AddressPage(this.page);
+  await addressPage.clickBackOnPage();
+});
+
 Then("they should continue to the confirm page", async function () {
   const addressPage = new AddressPage(this.page);
   await addressPage.continue();


### PR DESCRIPTION
## Proposed changes

### What changed

Added an additional check to the if statement that the URL starts with '/previous', to indicate we are in the previous flow.

### Why did it change

The results controller is shared between the first & previous flow. There is logic to validate the address when going through the previous flow is different to the first address. Although this also ran this validation if a user selected an address in the first flow but click back after.

### Issue tracking

- [OJ-3712](https://govukverify.atlassian.net/browse/OJ-3712)


[OJ-3712]: https://govukverify.atlassian.net/browse/OJ-3712?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ