### PR TITLE
OJ-3742: New post-merge GHA

### DIFF
--- a/.github/workflows/post-merge-to-build.yml
+++ b/.github/workflows/post-merge-to-build.yml
@@ -1,9 +1,6 @@
 name: Docker build, ECR push, template copy to S3
 on:
-  push:
-    branches:
-      - main
-  workflow_dispatch: # deploy manually
+  workflow_call:
 
 jobs:
   dockerBuildAndPush:

--- a/.github/workflows/post-merge-to-dev.yml
+++ b/.github/workflows/post-merge-to-dev.yml
@@ -1,8 +1,6 @@
 name: Development Docker build, ECR push, template copy to S3
 on:
-  push:
-    branches:
-      - main
+  workflow_call:
   workflow_dispatch: # deploy manually
 
 jobs:

--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -1,0 +1,20 @@
+name: Scan, Test, Build, Package & Deploy
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  scan-and-unit-test:
+    name: Scan repo
+    uses: ./.github/workflows/scan-repo.yml
+
+  deploy-dev:
+    name: Package for dev
+    needs: scan-and-unit-test
+    uses: ./.github/workflows/post-merge-to-dev.yml
+
+  deploy-build:
+    name: Package for build
+    needs: scan-and-unit-test
+    uses: ./.github/workflows/post-merge-to-build.yml

--- a/.github/workflows/scan-repo.yml
+++ b/.github/workflows/scan-repo.yml
@@ -3,8 +3,7 @@ name: Scan repository
 on:
   workflow_dispatch:
   pull_request:
-  push:
-    branches: [main]
+  workflow_call:
   schedule:
     # Every Monday at 9am
     - cron: "0 9 * * 1"


### PR DESCRIPTION
## Proposed changes

### What changed

Created a new `post-merge.yml `GHA. 

### Why did it change

We previously deployed even if scan-repo failed post-merge. This now makes deploying depend on scan-repo completing successfully.

### Issue tracking

- [OJ-3742](https://govukverify.atlassian.net/browse/OJ-3742)

[OJ-3742]: https://govukverify.atlassian.net/browse/OJ-3742?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ