### PR TITLE
fix: stop missing /public asset requests from erroring live journeys

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "dev": "nodemon src/app.js",
     "build": "npm run build-sass && npm run build-js && npm run copy-assets && npm run copy-js",
     "build-sass": "rm -rf dist/public/stylesheets/application.css && sass --no-source-map src/assets/scss/application.scss dist/public/stylesheets/application.css --style compressed",
-    "copy-assets": "mkdir -p dist/public/govuk && copyfiles -u 1 src/**/*.njk dist/ src/locales/**/** dist/ && copyfiles -u 3 src/assets/javascript/*.js dist/public/scripts && copyfiles -u 3 src/assets/images/** dist/public/images && cp node_modules/govuk-frontend/dist/govuk/govuk-frontend.min.js dist/public/govuk/govuk-frontend.min.js",
+    "copy-assets": "mkdir -p dist/public/govuk && copyfiles -u 1 src/**/*.njk dist/ src/locales/**/** dist/ && copyfiles -u 3 src/assets/javascript/*.js dist/public/scripts && copyfiles -u 3 src/assets/images/** dist/public/images && cp node_modules/govuk-frontend/dist/govuk/govuk-frontend.min.js dist/public/govuk/govuk-frontend.min.js && cp node_modules/govuk-frontend/dist/govuk/govuk-frontend.min.js.map dist/public/govuk/govuk-frontend.min.js.map",
     "build-js": "npm run build-js:analytics && npm run build-js:device-intelligence && npm run build-js:all",
     "copy-js": "copyfiles -u 3 node_modules/accessible-autocomplete/dist/accessible-autocomplete.min.js node_modules/accessible-autocomplete/dist/accessible-autocomplete.min.js.map dist/public/javascripts",
     "build-js:analytics": "mkdir -p dist/public/javascripts; uglifyjs node_modules/@govuk-one-login/frontend-analytics/lib/analytics.js node_modules/@govuk-one-login/di-ipv-cri-common-express/src/assets/javascript/analytics/ua/init.js --beautify -o dist/public/javascripts/analytics.js",

--- a/src/app.js
+++ b/src/app.js
@@ -84,6 +84,10 @@ const { app, router } = setup({
     "views",
   ],
   middlewareSetupFn: (app) => {
+    // Any request under /public reaching here missed the static-file middleware (the file isn't on disk) so to prevent it
+    // from falling through, we make it 404 otherwise it'll  fall through to getLanguageToggle and 302
+    app.use("/public", (req, res) => res.status(404).end());
+
     frontendVitalSignsInitFromApp(app, {
       interval: 60000,
       logLevel: "info",


### PR DESCRIPTION
## Proposed changes

### What changed
* Added a`/public` so that we return 404 for any asset request missing a file
* copy-assets now includes `govuk-frontend.min.js.map`


### Issue tracking
- BAU
