### PR TITLE
chore: bump common-express to v16.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       ],
       "dependencies": {
         "@aws-sdk/client-dynamodb": "3.1005.0",
-        "@govuk-one-login/di-ipv-cri-common-express": "16.1.0",
+        "@govuk-one-login/di-ipv-cri-common-express": "16.2.0",
         "@govuk-one-login/frontend-analytics": "4.0.5",
         "@govuk-one-login/frontend-device-intelligence": "1.1.0",
         "@govuk-one-login/frontend-language-toggle": "1.1.0",
@@ -1436,9 +1436,9 @@
       }
     },
     "node_modules/@govuk-one-login/di-ipv-cri-common-express": {
-      "version": "16.1.0",
-      "resolved": "https://registry.npmjs.org/@govuk-one-login/di-ipv-cri-common-express/-/di-ipv-cri-common-express-16.1.0.tgz",
-      "integrity": "sha512-K1k8/mrX5jp+RSl5F9RwMmE1wR2aMlmaKlT3e212SsUW2KHNn3d4pRR9Vo4UVllAd4+EylAGULpgrpkKwQM8tg==",
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/@govuk-one-login/di-ipv-cri-common-express/-/di-ipv-cri-common-express-16.2.0.tgz",
+      "integrity": "sha512-TnF+p8OK3Ce7N6uA9b/HcJsQ2PYaERjdRb3xNi3V50K+EBjMO7W4Xl+uxWkEVXpETzuIIQS8J/oWmlMba44Frg==",
       "license": "MIT",
       "dependencies": {
         "async": "3.2.6",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-dynamodb": "3.1005.0",
-    "@govuk-one-login/di-ipv-cri-common-express": "16.1.0",
+    "@govuk-one-login/di-ipv-cri-common-express": "16.2.0",
     "@govuk-one-login/frontend-analytics": "4.0.5",
     "@govuk-one-login/frontend-device-intelligence": "1.1.0",
     "@govuk-one-login/frontend-language-toggle": "1.1.0",


### PR DESCRIPTION
## Proposed changes

### What changed
Bump common-express to v16.2.0

### Issue tracking
- [OJ-3799](https://govukverify.atlassian.net/browse/OJ-3799)


[OJ-3799]: https://govukverify.atlassian.net/browse/OJ-3799?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ