### PR TITLE
feat: add request-count autoscaling policy

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -96,11 +96,13 @@ Mappings:
       minECSCount: 1
       maxECSCount: 4
       logLevel: "info"
+      requestCountTargetPerTarget: 100
     build:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
       minECSCount: 2
       maxECSCount: 60
       logLevel: "info"
+      requestCountTargetPerTarget: 100
     staging:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
       minECSCount: 2
@@ -817,6 +819,32 @@ Resources:
         PredefinedMetricSpecification:
           PredefinedMetricType: ECSServiceAverageCPUUtilization
         TargetValue: 30
+        ScaleInCooldown: 420
+        ScaleOutCooldown: 60
+
+  ECSRequestCountScalingPolicy:
+    Condition: IsDevBuildEnvironment
+    DependsOn: ECSAutoScalingTarget
+    Type: AWS::ApplicationAutoScaling::ScalingPolicy
+    Properties:
+      PolicyName: ECSRequestCountScalingPolicy
+      PolicyType: TargetTrackingScaling
+      ResourceId: !Sub service/${AddressFrontEcsCluster}/${AddressFrontEcsService.Name}
+      ScalableDimension: ecs:service:DesiredCount
+      ServiceNamespace: ecs
+      TargetTrackingScalingPolicyConfiguration:
+        PredefinedMetricSpecification:
+          PredefinedMetricType: ALBRequestCountPerTarget
+          ResourceLabel: !Join
+            - "/"
+            - - !GetAtt LoadBalancer.LoadBalancerFullName
+              - !GetAtt LoadBalancerListenerTargetGroupECS.TargetGroupFullName
+        TargetValue:
+          !FindInMap [
+            EnvironmentConfiguration,
+            !Ref Environment,
+            requestCountTargetPerTarget,
+          ]
         ScaleInCooldown: 420
         ScaleOutCooldown: 60
 


### PR DESCRIPTION
## Proposed changes

### What changed
In dev/build added a new `ALBRequestCountPerTarget` target-tracking scaling policy alongside the existing CPU policy


### Why did it change
During perf tests we were getting 503s from the overload-protection, this looks to be happening because we're not scaling out enough.


### Issue tracking
- [OJ-3765](https://govukverify.atlassian.net/browse/OJ-3765)


[OJ-3765]: https://govukverify.atlassian.net/browse/OJ-3765?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ