### PR TITLE
Fix stale address data when searching with a new postcode [OJ-3816]

### DIFF
--- a/src/app/address/controllers/address/search.js
+++ b/src/app/address/controllers/address/search.js
@@ -18,6 +18,7 @@ export class AddressSearchController extends FormWizard.Controller {
 
     const addressPostcode = req.body["addressSearch"];
 
+    req.sessionModel.unset("address");
     req.sessionModel.set("addressSearch", addressPostcode);
 
     try {

--- a/src/app/address/controllers/address/search.test.js
+++ b/src/app/address/controllers/address/search.test.js
@@ -60,6 +60,23 @@ describe("Address Search controller", function () {
         headers,
       });
     });
+    it("should remove a previously selected address when searching using a different postcode", async () => {
+      req.sessionModel.set("address", {
+        buildingName: "East Zzz",
+        postalCode: "ZZ1 1ZZ",
+      });
+
+      req.body["addressSearch"] = "E1 8QS";
+
+      req.customFetch = vi
+        .fn()
+        .mockResolvedValue(new Response(JSON.stringify(apiResponse.data)));
+
+      await addressSearch.saveValues(req, res, next);
+
+      expect(req.sessionModel.get("address")).toBeUndefined();
+      expect(req.sessionModel.get("addressPostcode")).toBe("E1 8QS");
+    });
 
     describe("on api success", () => {
       let testPostcode;


### PR DESCRIPTION


### What changed

Clear any previously selected address when a new postcode search is performed.
Reset stale address state before storing the new postcode search results.

### Why did it change
Previously, address data from an earlier postcode search could remain in the session and be reused when the user started a new postcode search.
This caused address fields to be pre-populated with stale values and prevented the journey from behaving consistently when navigating back and searching with a different postcode.
Clearing the stored address ensures each postcode search starts with a clean address state.

### Issue tracking

- [OJ-3816](https://govukverify.atlassian.net/browse/OJ-3816)


https://github.com/user-attachments/assets/f1d603b3-3337-487f-afa2-9c6a4fbc9c20



[OJ-3816]: https://govukverify.atlassian.net/browse/OJ-3816?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ